### PR TITLE
update to Zig `0.14.0-dev.2934+8ba3812ee`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,10 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/ztl.zig"),
         .target = target,
         .optimize = optimize,
-        .test_runner = b.path("test_runner.zig"),
+        .test_runner = .{
+            .path = b.path("test_runner.zig"),
+            .mode = .simple,
+        },
     });
 
     const run_test = b.addRunArtifact(tests);


### PR DESCRIPTION
* Breaking change for specifying test runner in `build.zig`: https://www.github.com/ziglang/zig/pull/22548
* and yet another change for panic handlers: https://www.github.com/ziglang/zig/pull/22594