### PR TITLE
Allow non-const app

### DIFF
--- a/src/vm.zig
+++ b/src/vm.zig
@@ -66,7 +66,6 @@ pub fn VM(comptime App: type) type {
                 return .{ .null = {} };
             }
 
-            const app = self.app;
             const code = byte_code[9..code_end];
             const data = byte_code[code_end..];
 
@@ -498,7 +497,7 @@ pub fn VM(comptime App: type) type {
                         const function_id = @as(u16, @bitCast(ip[0..2].*));
                         ip += 2;
 
-                        const result = try app.call(self, @enumFromInt(function_id), stack.items[stack.items.len - arity ..]);
+                        const result = try self.app.call(self, @enumFromInt(function_id), stack.items[stack.items.len - arity ..]);
                         self.releaseCount(stack, arity);
                         try stack.append(allocator, result);
                     },


### PR DESCRIPTION
If the app for `ztl.Template` has a state, you will get the following error:
```
/home/ross/.cache/zig/p/ztl-0.0.0-XMYgXAjJBACjad2q-qlRgusVcp6aG69Nfg_LSx14_4wq/src/vm.zig:501:47: error: expected type '*Workflow.Formatter', found '*const Workflow.Formatter'
                        const result = try app.call(self, @enumFromInt(function_id), stack.items[stack.items.len - arity ..]);
                                           ~~~^~~~~
/home/ross/.cache/zig/p/ztl-0.0.0-XMYgXAjJBACjad2q-qlRgusVcp6aG69Nfg_LSx14_4wq/src/vm.zig:501:47: note: cast discards const qualifier
src/Workflow.zig:174:23: note: parameter type declared here
    pub fn call(self: *Formatter, vm: *ztl.VM(Formatter), func: ztl.Functions(Formatter), values: []ztl.Value) !ztl.Value {
                      ^~~~~~~~~~
```
This is because the app's `call` function cannot have `self` as a constant pointer. The hacky way around this is to use `@constCast()` but this PR has a better solution.