### PR TITLE
Update to Zig 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-out/
+zig-pkg/
 .zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -10,9 +10,11 @@ pub fn build(b: *std.Build) !void {
 
     // setup tests
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/ztl.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/ztl.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
         .test_runner = .{
             .path = b.path("test_runner.zig"),
             .mode = .simple,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,6 +3,5 @@
 	.paths = .{""},
 	.version = "0.0.0",
 	.fingerprint = 0xa970a5155c20c65c,
-	.dependencies = .{
-	},
+	.minimum_zig_version = "0.16.0",
 }

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,8 @@ const Product = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     var template = ztl.Template(void).init(allocator, {});
@@ -23,7 +24,7 @@ pub fn main() !void {
         \\ <% foreach (@products) |product| { -%>
         \\     <%= escape product["name"] %>
         \\ <% } %>
-    , .{.error_report = &compile_error_report}) catch |err| {
+    , .{ .error_report = &compile_error_report }) catch |err| {
         std.debug.print("{}\n", .{compile_error_report});
         return err;
     };
@@ -34,12 +35,12 @@ pub fn main() !void {
     var render_error_report = ztl.RenderErrorReport{};
 
     // The render method is thread-safe.
-    template.render(buf.writer(), .{
+    template.render(&aw.writer, .{
         .products = [_]Product{
-            .{.name = "Keemun"},
-            .{.name = "Silver Needle"},
-        }
-    }, .{.error_report = &render_error_report}) catch |err| {
+            .{ .name = "Keemun" },
+            .{ .name = "Silver Needle" },
+        },
+    }, .{ .error_report = &render_error_report }) catch |err| {
         defer render_error_report.deinit();
         std.debug.print("{}\n", .{render_error_report});
         return err;

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,8 @@ pub fn main() !void {
         return err;
     };
 
-    // Write to any writer, here we're using an ArrayList
-    var buf = std.ArrayList(u8).init(allocator);
-    defer buf.deinit();
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
 
     var render_error_report = ztl.RenderErrorReport{};
 
@@ -46,7 +45,7 @@ pub fn main() !void {
         return err;
     };
 
-    std.debug.print("{s}\n", .{buf.items});
+    std.debug.print("{s}\n", .{aw.written()});
 }
 ```
 

--- a/src/byte_code.zig
+++ b/src/byte_code.zig
@@ -358,7 +358,7 @@ fn Buffer(comptime initial_size: u32) type {
     };
 }
 
-pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const u8, writer: anytype) !void {
+pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const u8, writer: *std.Io.Writer) !void {
     const LocalIndex = config.LocalType(App);
     const SL = @sizeOf(LocalIndex);
 
@@ -371,7 +371,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
 
     const code = byte_code[9 .. code_length + 9];
     const data = byte_code[9 + code_length ..];
-    try std.fmt.format(writer, "// Version: {d}\n", .{byte_code[0]});
+    try writer.print("// Version: {d}\n", .{byte_code[0]});
 
     while (i < code.len) {
         if (i == script_start) {
@@ -381,12 +381,12 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
             try writer.writeAll("<main>:\n");
         }
         const op_code_pos = i;
-        const op_code = std.meta.intToEnum(OpCode, code[i]) catch {
-            try std.fmt.format(writer, "{x:0>4} ??? ({d})", .{ i, code[i] });
+        const op_code = std.enums.fromInt(OpCode, code[i]) orelse {
+            try writer.print("{x:0>4} ??? ({d})", .{ i, code[i] });
             return;
         };
         if (op_code != .DEBUG) {
-            try std.fmt.format(writer, "{x:0>4} {s}", .{ i, @tagName(op_code) });
+            try writer.print("{x:0>4} {s}", .{ i, @tagName(op_code) });
         }
 
         i += 1;
@@ -404,7 +404,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                         }
                         const function_name_len: u16 = @bitCast(code[i .. i + 2][0..2].*);
                         i += 2;
-                        try std.fmt.format(writer, "{x:0>4} fn {s}:\n", .{ op_code_pos, code[i .. i + function_name_len] });
+                        try writer.print("{x:0>4} fn {s}:\n", .{ op_code_pos, code[i .. i + function_name_len] });
                         i += function_name_len;
                     },
                     .VARIABLE_NAME => {
@@ -438,23 +438,23 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                             prefix = "\n";
                         }
 
-                        try std.fmt.format(writer, "{s}{x:0>4} // {s}\n", .{ prefix, op_code_pos, comment });
+                        try writer.print("{s}{x:0>4} // {s}\n", .{ prefix, op_code_pos, comment });
                         i += len;
                     },
                 }
             },
             .CONSTANT_I64 => {
                 const value = @as(*align(1) const i64, @ptrCast(code[i..(i + 8)])).*;
-                try std.fmt.format(writer, " {d}\n", .{value});
+                try writer.print(" {d}\n", .{value});
                 i += 8;
             },
             .CONSTANT_F64 => {
                 const value = @as(*align(1) const f64, @ptrCast(code[i..(i + 8)])).*;
-                try std.fmt.format(writer, " {d}\n", .{value});
+                try writer.print(" {d}\n", .{value});
                 i += 8;
             },
             .CONSTANT_BOOL => {
-                try std.fmt.format(writer, " {any}\n", .{code[i] == 1});
+                try writer.print(" {any}\n", .{code[i] == 1});
                 i += 1;
             },
             .CONSTANT_STRING => {
@@ -462,33 +462,33 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                 i += 4;
                 const header_end = header_start + 4;
                 const string_end = @as(u32, @bitCast(data[header_start..header_end][0..4].*));
-                try std.fmt.format(writer, " `{s}`\n", .{data[header_end..string_end]});
+                try writer.print(" `{s}`\n", .{data[header_end..string_end]});
             },
             .JUMP => {
                 const relative = @as(i16, @bitCast(code[i .. i + 2][0..2].*));
                 const target: u32 = @intCast(@as(i32, @intCast(i)) + relative);
-                try std.fmt.format(writer, " {x:0>4}\n", .{target});
+                try writer.print(" {x:0>4}\n", .{target});
                 i += 2;
             },
             .JUMP_IF_FALSE, .JUMP_IF_FALSE_POP => {
                 const relative = @as(i16, @bitCast(code[i .. i + 2][0..2].*));
                 const target: u32 = @intCast(@as(i32, @intCast(i)) + relative);
-                try std.fmt.format(writer, " {x:0>4}\n", .{target});
+                try writer.print(" {x:0>4}\n", .{target});
                 i += 2;
             },
             .GET_GLOBAL, .GET_LOCAL => {
                 const idx = @as(LocalIndex, @bitCast(code[i .. i + SL][0..SL].*));
-                try std.fmt.format(writer, " {s}@{d}\n", .{ variable_names.get(idx) orelse "", idx });
+                try writer.print(" {s}@{d}\n", .{ variable_names.get(idx) orelse "", idx });
                 i += SL;
             },
             .SET_GLOBAL, .SET_LOCAL => {
                 const idx = @as(LocalIndex, @bitCast(code[i .. i + SL][0..SL].*));
-                try std.fmt.format(writer, " {s}@{d}\n", .{ variable_names.get(idx) orelse "", idx });
+                try writer.print(" {s}@{d}\n", .{ variable_names.get(idx) orelse "", idx });
                 i += SL;
             },
             .PROPERTY_GET => {
                 const prop: Property = @enumFromInt(@as(u16, @bitCast(code[i .. i + 2][0..2].*)));
-                try std.fmt.format(writer, " {s}\n", .{@tagName(prop)});
+                try writer.print(" {s}\n", .{@tagName(prop)});
                 i += 2;
             },
             .METHOD => {
@@ -497,7 +497,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
 
                 const m: Method = @enumFromInt(@as(u16, @bitCast(code[i .. i + 2][0..2].*)));
                 i += 2;
-                try std.fmt.format(writer, " {s}({d})\n", .{ @tagName(m), arity });
+                try writer.print(" {s}({d})\n", .{ @tagName(m), arity });
             },
             .INCR_GLOBAL, .INCR_LOCAL => {
                 // i += 0 is pretty rare. So use value 0 for -1, which is more
@@ -506,7 +506,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                 i += 1;
                 const idx = @as(LocalIndex, @bitCast(code[i .. i + SL][0..SL].*));
                 i += SL;
-                try std.fmt.format(writer, " {s}@{d} {d}\n", .{ variable_names.get(idx) orelse "", idx, value });
+                try writer.print(" {s}@{d} {d}\n", .{ variable_names.get(idx) orelse "", idx, value });
             },
             .INITIALIZE => {
                 const initialize_type: OpCode.Initialize = @enumFromInt(code[i]);
@@ -514,7 +514,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                 switch (initialize_type) {
                     .ARRAY, .MAP => {
                         const value_count: u32 = @bitCast(code[i .. i + 4][0..4].*);
-                        try std.fmt.format(writer, " {s} {d}\n", .{ @tagName(initialize_type), value_count });
+                        try writer.print(" {s} {d}\n", .{ @tagName(initialize_type), value_count });
                         i += 4;
                     },
                 }
@@ -522,7 +522,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
             .POP => {
                 const count = code[i];
                 i += 1;
-                try std.fmt.format(writer, " {d}\n", .{count});
+                try writer.print(" {d}\n", .{count});
             },
             .CALL_ZIG => {
                 const arity = code[i];
@@ -532,7 +532,7 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                 i += 2;
 
                 const name = @tagName(@as(ztl.Functions(App), @enumFromInt(function_id)));
-                try std.fmt.format(writer, " {s}({d})\n", .{ name, arity });
+                try writer.print(" {s}({d})\n", .{ name, arity });
             },
             .CALL => {
                 const header_start = @as(u32, @bitCast(code[i .. i + 4][0..4].*));
@@ -541,13 +541,13 @@ pub fn disassemble(comptime App: type, allocator: Allocator, byte_code: []const 
                 const arity = data[header_start];
                 var d = data[header_start + 1 ..];
                 const jump: u32 = @bitCast(d[0..4].*);
-                try std.fmt.format(writer, " {d} {x:0>4}", .{ arity, jump });
+                try writer.print(" {d} {x:0>4}", .{ arity, jump });
                 if (comptime config.shouldDebug(App, .minimal)) {
                     d = d[4..];
                     const name_length = d[0];
-                    try std.fmt.format(writer, " ({s})", .{d[1 .. name_length + 1]});
+                    try writer.print(" ({s})", .{d[1 .. name_length + 1]});
                 }
-                try std.fmt.format(writer, "\n", .{});
+                try writer.print("\n", .{});
             },
             .FOREACH, .FOREACH_ITERATE => {
                 std.debug.print(" {d}\n", .{code[i]});
@@ -763,12 +763,13 @@ test "bytecode: functions debug full" {
 }
 
 fn expectDisassemble(comptime App: type, b: anytype, expected: []const u8) !void {
-    var arr = std.ArrayList(u8).init(t.allocator);
-    defer arr.deinit();
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
 
     const byte_code = try b.toBytes(t.allocator);
     defer t.allocator.free(byte_code);
 
-    try disassemble(App, t.allocator, byte_code, arr.writer());
-    try t.expectString(expected, arr.items);
+    try disassemble(App, t.allocator, byte_code, &aw.writer);
+
+    try t.expectString(expected, aw.written());
 }

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -37,10 +37,10 @@ pub fn Compiler(comptime A: type) type {
 
         const valid_parameters = blk: {
             if (params.len == 4) {
-                break :blk  params[0].type.? == A and
-                            params[1].type.? == Allocator and
-                            params[2].type.? == []const u8 and
-                            params[3].type.? == []const u8;
+                break :blk params[0].type.? == A and
+                    params[1].type.? == Allocator and
+                    params[2].type.? == []const u8 and
+                    params[3].type.? == []const u8;
             }
             break :blk false;
         };
@@ -123,7 +123,11 @@ pub fn Compiler(comptime A: type) type {
         const Self = @This();
 
         // we expect allocator to be an arena
-        pub fn init(allocator: Allocator, app: A, opts: Opts,) !Self {
+        pub fn init(
+            allocator: Allocator,
+            app: A,
+            opts: Opts,
+        ) !Self {
             return .{
                 .app = app,
                 .err = null,
@@ -217,7 +221,7 @@ pub fn Compiler(comptime A: type) type {
         }
 
         fn consumeSemicolon(self: *Self, allow_close_tag: bool) !void {
-            if (try self.match(.SEMICOLON))  {
+            if (try self.match(.SEMICOLON)) {
                 return;
             }
             if (allow_close_tag) {
@@ -280,7 +284,7 @@ pub fn Compiler(comptime A: type) type {
                     }
                     try self.writer.op(op_code);
                 },
-                .code =>  switch (self.current) {
+                .code => switch (self.current) {
                     .PERCENT_GREATER => {
                         self.mode = .literal;
                         return;
@@ -373,7 +377,7 @@ pub fn Compiler(comptime A: type) type {
                         }
                     },
                     else => return self.statement(),
-                }
+                },
             }
         }
 
@@ -431,7 +435,7 @@ pub fn Compiler(comptime A: type) type {
                     continue;
                 }
 
-                var lit = src[start..idx - 1];
+                var lit = src[start .. idx - 1];
                 // skip the %
                 pos = idx + 1;
 
@@ -803,12 +807,12 @@ pub fn Compiler(comptime A: type) type {
                             return error.PartialsNotConfigured;
                         }
 
-                       const include_key = switch (self.current) {
+                        const include_key = switch (self.current) {
                             .STRING => |str| str,
                             else => {
                                 try self.setExpectationError("partial name (a string literal)");
                                 return error.Invalid;
-                            }
+                            },
                         };
 
                         for (self.includes.items) |incl| {
@@ -843,7 +847,7 @@ pub fn Compiler(comptime A: type) type {
 
                         // Ask the app for the include source
                         const result = self.app.partial(self.arena, self.opts.key, include_key) catch |err| {
-                            try self.setErrorFmt("Failed to load partial: '{s}'. Load Error: {}", .{include_key, err});
+                            try self.setErrorFmt("Failed to load partial: '{s}'. Load Error: {}", .{ include_key, err });
                             return error.PartialLoadError;
                         } orelse {
                             try self.setErrorFmt("Unknown partial: '{s}'", .{include_key});
@@ -856,7 +860,7 @@ pub fn Compiler(comptime A: type) type {
                         try self.beginInclude(include_key, result.src);
 
                         try self.beginScope(false);
-                        try self.locals.append(self.arena, .{.name = include_fn_name, .depth = 0});
+                        try self.locals.append(self.arena, .{ .name = include_fn_name, .depth = 0 });
                         gop.value_ptr.* = try self.newFunction(include_fn_name);
                         try writer.beginFunction(include_fn_name);
 
@@ -1160,7 +1164,6 @@ pub fn Compiler(comptime A: type) type {
                         else => {
                             try self.setErrorFmt("Map key must be an integer, string or identifier, got {f} ({s})", .{ current_token, @tagName(current_token) });
                             return error.InvalidMapKeyType;
-
                         },
                     }
                     try self.advance();
@@ -1508,8 +1511,8 @@ pub fn Compiler(comptime A: type) type {
 
             self.scanner.reset(src);
             self.mode = .literal;
-            self.previous = .{.BOF = {}};
-            self.current = .{.BOF = {}};
+            self.previous = .{ .BOF = {} };
+            self.current = .{ .BOF = {} };
             self.global_mode = .include;
         }
 
@@ -1567,9 +1570,9 @@ pub fn Compiler(comptime A: type) type {
 }
 
 const Mode = enum {
-    code,     // <% ... %>
-    output,   // <%= ... %>
-    literal,  // everything NOT in the above
+    code, // <% ... %>
+    output, // <%= ... %>
+    literal, // everything NOT in the above
     literal_strip_left,
 };
 
@@ -3574,11 +3577,11 @@ test "Compiler: method concat" {
 
 test "Compiler: method toString" {
     try testError("Function 'toString' expects 0 parameters, but called with 2", "return [].toString('', 0)");
-    try testReturnValue(.{.string = "abc"}, "return 'abc'.toString(); ");
-    try testReturnValue(.{.string = "123aabz"}, "return '123aabz'.toString().toString(); ");
-    try testReturnValue(.{.string = "3"}, "return 3.toString(); ");
-    try testReturnValue(.{.string = "false"}, "return false.toString(); ");
-    try testReturnValue(.{.string = "[1, 2, 3]"}, "return [1,2,3].toString(); ");
+    try testReturnValue(.{ .string = "abc" }, "return 'abc'.toString(); ");
+    try testReturnValue(.{ .string = "123aabz" }, "return '123aabz'.toString().toString(); ");
+    try testReturnValue(.{ .string = "3" }, "return 3.toString(); ");
+    try testReturnValue(.{ .string = "false" }, "return false.toString(); ");
+    try testReturnValue(.{ .string = "[1, 2, 3]" }, "return [1,2,3].toString(); ");
 }
 
 test "Compiler: partial" {
@@ -3601,15 +3604,15 @@ test "Compiler: partial" {
             }
 
             if (std.mem.eql(u8, include_key, "incl_dbl")) {
-                return .{.src = "<% fn dbl(a) { return a * 2; } %>"};
+                return .{ .src = "<% fn dbl(a) { return a * 2; } %>" };
             }
 
             if (std.mem.eql(u8, include_key, "recursive_1")) {
-                return .{.src = "<% @include('recursive_2') %>"};
+                return .{ .src = "<% @include('recursive_2') %>" };
             }
 
             if (std.mem.eql(u8, include_key, "recursive_2")) {
-                return .{.src = "<% @include('recursive_1') %>"};
+                return .{ .src = "<% @include('recursive_1') %>" };
             }
 
             return null;
@@ -3636,7 +3639,7 @@ test "Compiler: partial" {
         \\ @include("recursive_1");
     );
 
-    try testReturnValueWithApp(App, .{}, .{.i64 = 12350},
+    try testReturnValueWithApp(App, .{}, .{ .i64 = 12350 },
         \\ @include("incl_dbl");
         \\ return dbl(6175);
     );
@@ -3670,9 +3673,9 @@ fn testReturnValueWithApp(comptime App: type, app: App, expected: Value, comptim
 
     const byte_code = blk: {
         var error_report = ztl.CompileErrorReport{};
-        var c = try Compiler(App).init(allocator, app, .{.error_report = &error_report});
+        var c = try Compiler(App).init(allocator, app, .{ .error_report = &error_report });
         c.compile("<% " ++ src ++ "%>") catch |err| {
-            std.debug.print("Compilation error: {any}\n{f}\n", .{err, error_report});
+            std.debug.print("Compilation error: {any}\n{f}\n", .{ err, error_report });
             return err;
         };
         break :blk try c.writer.toBytes(allocator);
@@ -3683,6 +3686,7 @@ fn testReturnValueWithApp(comptime App: type, app: App, expected: Value, comptim
     var vm = ztl.VM(App).init(allocator, app);
 
     var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
     const value = vm.run(byte_code, &aw.writer) catch |err| {
         std.debug.print("{any}", .{err});
         if (vm.err) |e| {
@@ -3711,7 +3715,7 @@ fn testError(expected: []const u8, comptime src: []const u8) !void {
 
 fn testErrorWithApp(comptime App: type, app: App, expected: []const u8, comptime src: []const u8) !void {
     var error_report = ztl.CompileErrorReport{};
-    var c = Compiler(App).init(t.arena.allocator(), app, .{.error_report = &error_report}) catch unreachable;
+    var c = Compiler(App).init(t.arena.allocator(), app, .{ .error_report = &error_report }) catch unreachable;
 
     c.compile("<% " ++ src ++ " %>") catch {
         var aw: std.Io.Writer.Allocating = .init(t.allocator);
@@ -3719,7 +3723,7 @@ fn testErrorWithApp(comptime App: type, app: App, expected: []const u8, comptime
 
         try aw.writer.print("{f}", .{error_report});
         if (std.mem.indexOf(u8, aw.written(), expected) == null) {
-            std.debug.print("Wrong error\nexpected: '{s}'\nactual:   '{s}'\n", .{ expected, aw.written()});
+            std.debug.print("Wrong error\nexpected: '{s}'\nactual:   '{s}'\n", .{ expected, aw.written() });
             return error.WrongError;
         }
         return;
@@ -3734,9 +3738,9 @@ fn testErrorWithApp(comptime App: type, app: App, expected: []const u8, comptime
 
 fn testRuntimeError(expected: []const u8, comptime src: []const u8) !void {
     var error_report = ztl.CompileErrorReport{};
-    var c = try Compiler(void).init(t.arena.allocator(), {}, .{.error_report = &error_report});
+    var c = try Compiler(void).init(t.arena.allocator(), {}, .{ .error_report = &error_report });
     c.compile("<% " ++ src ++ " %>") catch |err| {
-        std.debug.print("Compilation error: {any}\n{f}\n", .{err, error_report});
+        std.debug.print("Compilation error: {any}\n{f}\n", .{ err, error_report });
         return err;
     };
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -95,15 +95,15 @@ pub fn Compiler(comptime A: type) type {
         // a stack of includes, used to track restoring the compiler/scanner state
         // after the include is included, as well as the src/name of the include
         // for error reporting purposes
-        includes: std.ArrayListUnmanaged(Include),
+        includes: std.ArrayList(Include),
 
         functions: std.StringHashMapUnmanaged(Function),
-        function_calls: std.ArrayListUnmanaged(Function.Call),
+        function_calls: std.ArrayList(Function.Call),
 
         // Used to track the scope that we're in
         // Also assigned to a local to determine in what scope the local can be used
-        scopes: std.ArrayListUnmanaged(Scope),
-        locals: std.ArrayListUnmanaged(Local),
+        scopes: std.ArrayList(Scope),
+        locals: std.ArrayList(Local),
 
         // list of @global variables
         globals: std.StringHashMapUnmanaged(usize),
@@ -128,15 +128,15 @@ pub fn Compiler(comptime A: type) type {
                 .app = app,
                 .err = null,
                 .opts = opts,
-                .scopes = .{},
-                .locals = .{},
-                .globals = .{},
-                .includes = .{},
-                .functions = .{},
+                .scopes = .empty,
+                .locals = .empty,
+                .globals = .empty,
+                .includes = .empty,
+                .functions = .empty,
                 .mode = .literal,
                 .arena = allocator,
-                .function_calls = .{},
-                .string_literals = .{},
+                .function_calls = .empty,
+                .string_literals = .empty,
                 .global_mode = .normal,
                 .jumper = Jumper(A).init(allocator),
                 .writer = try ByteCode(A).init(allocator),
@@ -396,7 +396,7 @@ pub fn Compiler(comptime A: type) type {
                 if (idx == end) {
                     var lit = src[start..];
                     if (self.mode == .literal_strip_left) {
-                        lit = std.mem.trimLeft(u8, lit, &std.ascii.whitespace);
+                        lit = std.mem.trimStart(u8, lit, &std.ascii.whitespace);
                     }
                     if (lit.len > 0) {
                         _ = try writer.string(lit);
@@ -419,7 +419,7 @@ pub fn Compiler(comptime A: type) type {
 
                     var lit = src[start..idx];
                     if (self.mode == .literal_strip_left) {
-                        lit = std.mem.trimLeft(u8, lit, &std.ascii.whitespace);
+                        lit = std.mem.trimStart(u8, lit, &std.ascii.whitespace);
                         self.mode = .literal;
                     }
                     if (lit.len > 0) {
@@ -438,11 +438,11 @@ pub fn Compiler(comptime A: type) type {
                 if (next == '-' and pos != end) {
                     pos += 1;
                     next = src[pos];
-                    lit = std.mem.trimRight(u8, lit, &std.ascii.whitespace);
+                    lit = std.mem.trimEnd(u8, lit, &std.ascii.whitespace);
                 }
 
                 if (self.mode == .literal_strip_left) {
-                    lit = std.mem.trimLeft(u8, lit, &std.ascii.whitespace);
+                    lit = std.mem.trimStart(u8, lit, &std.ascii.whitespace);
                     self.mode = .literal;
                 }
 
@@ -1158,7 +1158,7 @@ pub fn Compiler(comptime A: type) type {
                         .IDENTIFIER => |k| try self.stringLiteral(k),
                         .STRING => |k| try self.stringLiteral(k),
                         else => {
-                            try self.setErrorFmt("Map key must be an integer, string or identifier, got {} ({s})", .{ current_token, @tagName(current_token) });
+                            try self.setErrorFmt("Map key must be an integer, string or identifier, got {f} ({s})", .{ current_token, @tagName(current_token) });
                             return error.InvalidMapKeyType;
 
                         },
@@ -1545,7 +1545,7 @@ pub fn Compiler(comptime A: type) type {
 
         fn setExpectationError(self: *Self, comptime message: []const u8) Error!void {
             const current_token = self.current;
-            return self.setErrorFmt("Expected " ++ message ++ ", got {} ({s})", .{ current_token, @tagName(current_token) });
+            return self.setErrorFmt("Expected " ++ message ++ ", got {f} ({s})", .{ current_token, @tagName(current_token) });
         }
 
         fn setErrorMaxArity(self: *Self, name: []const u8) !void {
@@ -1691,21 +1691,21 @@ fn Jumper(comptime App: type) type {
         //   every new for/while adds a new entry
         //   The inner lists is because 1 loop can have multiple breaks
         //   so we potentially need to register/fill multiple JUMP locations
-        break_scopes: std.ArrayListUnmanaged(std.ArrayListUnmanaged(u32)),
+        break_scopes: std.ArrayList(std.ArrayList(u32)),
 
         // Same as breaks. In the case of a "while" loop, a continue will jump
         // back to the top of the loop. But in the case of a "for" loop, the
         // continue will jump forwards to the increment part of the loop (and
         // then jump back to the top)
-        continue_scopes: std.ArrayListUnmanaged(std.ArrayListUnmanaged(u32)),
+        continue_scopes: std.ArrayList(std.ArrayList(u32)),
 
         // For each scope, we record how deep we should pop on a break/continue
-        pop_depths: std.ArrayListUnmanaged(usize),
+        pop_depths: std.ArrayList(usize),
 
         const Self = @This();
 
         fn init(arena: Allocator) Self {
-            return .{ .arena = arena, .pop_depths = .{}, .break_scopes = .{}, .continue_scopes = .{} };
+            return .{ .arena = arena, .pop_depths = .empty, .break_scopes = .empty, .continue_scopes = .empty };
         }
 
         fn forward(_: *const Self, compiler: *Compiler(App), op_code: OpCode) !Forward {
@@ -1730,8 +1730,8 @@ fn Jumper(comptime App: type) type {
         }
 
         fn newBreakableScope(self: *Self, compiler: *Compiler(App)) !BreakableScope {
-            try self.break_scopes.append(self.arena, .{});
-            try self.continue_scopes.append(self.arena, .{});
+            try self.break_scopes.append(self.arena, .empty);
+            try self.continue_scopes.append(self.arena, .empty);
             try self.pop_depths.append(self.arena, compiler.scopeDepth());
             return .{
                 .jumper = self,
@@ -1747,7 +1747,7 @@ fn Jumper(comptime App: type) type {
             return self.recordBreakable(compiler, levels, self.continue_scopes.items, "continue");
         }
 
-        fn recordBreakable(self: *Self, compiler: *Compiler(App), levels: usize, list: []std.ArrayListUnmanaged(u32), comptime op: []const u8) !void {
+        fn recordBreakable(self: *Self, compiler: *Compiler(App), levels: usize, list: []std.ArrayList(u32), comptime op: []const u8) !void {
             const pop_depths = self.pop_depths.items;
             if (levels > pop_depths.len) {
                 if (pop_depths.len == 0) {
@@ -3672,7 +3672,7 @@ fn testReturnValueWithApp(comptime App: type, app: App, expected: Value, comptim
         var error_report = ztl.CompileErrorReport{};
         var c = try Compiler(App).init(allocator, app, .{.error_report = &error_report});
         c.compile("<% " ++ src ++ "%>") catch |err| {
-            std.debug.print("Compilation error: {any}\n{}\n", .{err, error_report});
+            std.debug.print("Compilation error: {any}\n{f}\n", .{err, error_report});
             return err;
         };
         break :blk try c.writer.toBytes(allocator);
@@ -3682,13 +3682,17 @@ fn testReturnValueWithApp(comptime App: type, app: App, expected: Value, comptim
 
     var vm = ztl.VM(App).init(allocator, app);
 
-    var buf: std.ArrayListUnmanaged(u8) = .{};
-    const value = vm.run(byte_code, buf.writer(t.allocator)) catch |err| {
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    const value = vm.run(byte_code, &aw.writer) catch |err| {
         std.debug.print("{any}", .{err});
         if (vm.err) |e| {
             std.debug.print("{any} {s}\n", .{ err, e });
         }
-        disassemble(App, allocator, byte_code, std.io.getStdErr().writer()) catch unreachable;
+        var stderr_lock = std.debug.lockStderr(&.{});
+        defer std.debug.unlockStderr();
+
+        const stderr = stderr_lock.terminal().writer;
+        disassemble(App, allocator, byte_code, stderr) catch unreachable;
         return err;
     };
 
@@ -3710,12 +3714,12 @@ fn testErrorWithApp(comptime App: type, app: App, expected: []const u8, comptime
     var c = Compiler(App).init(t.arena.allocator(), app, .{.error_report = &error_report}) catch unreachable;
 
     c.compile("<% " ++ src ++ " %>") catch {
-        var buf = std.ArrayListUnmanaged(u8){};
-        defer buf.deinit(t.allocator);
+        var aw: std.Io.Writer.Allocating = .init(t.allocator);
+        defer aw.deinit();
 
-        try std.fmt.format(buf.writer(t.allocator), "{}", .{error_report});
-        if (std.mem.indexOf(u8, buf.items, expected) == null) {
-            std.debug.print("Wrong error\nexpected: '{s}'\nactual:   '{s}'\n", .{ expected, buf.items});
+        try aw.writer.print("{f}", .{error_report});
+        if (std.mem.indexOf(u8, aw.written(), expected) == null) {
+            std.debug.print("Wrong error\nexpected: '{s}'\nactual:   '{s}'\n", .{ expected, aw.written()});
             return error.WrongError;
         }
         return;
@@ -3732,7 +3736,7 @@ fn testRuntimeError(expected: []const u8, comptime src: []const u8) !void {
     var error_report = ztl.CompileErrorReport{};
     var c = try Compiler(void).init(t.arena.allocator(), {}, .{.error_report = &error_report});
     c.compile("<% " ++ src ++ " %>") catch |err| {
-        std.debug.print("Compilation error: {any}\n{}\n", .{err, error_report});
+        std.debug.print("Compilation error: {any}\n{f}\n", .{err, error_report});
         return err;
     };
 
@@ -3745,9 +3749,9 @@ fn testRuntimeError(expected: []const u8, comptime src: []const u8) !void {
     var vm = ztl.VM(void).init(arena.allocator(), {});
     try checkVMForLeaks(&vm);
 
-    var buf: std.ArrayListUnmanaged(u8) = .{};
-    defer buf.deinit(t.allocator);
-    _ = vm.run(byte_code, buf.writer(t.allocator)) catch {
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
+    _ = vm.run(byte_code, &aw.writer) catch {
         if (std.mem.indexOf(u8, vm.err.?, expected) == null) {
             std.debug.print("Wrong error, expected: {s} but got:\n{s}\n", .{ expected, vm.err.? });
             return error.WrongError;

--- a/src/error_report.zig
+++ b/src/error_report.zig
@@ -9,7 +9,7 @@ pub const Compile = struct {
     message: []const u8 = "",
     include_key: ?[]const u8 = null,
 
-    pub fn format(self: *const Compile, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: *const Compile, writer: *std.Io.Writer) !void {
         if (self.err) |se| {
             try writer.writeAll(@errorName(se));
             try writer.writeAll(" - ");
@@ -19,14 +19,14 @@ pub const Compile = struct {
             try writer.writeAll(" - ");
         }
 
-        try std.fmt.format(writer, "line {d}:\n", .{self.lineNumber()});
+        try writer.print("line {d}:\n", .{self.lineNumber()});
 
         try writer.writeAll(self.contextBefore(2));
         try writer.writeAll(self.line());
         try writer.writeByte('\n');
 
         const c = self.column();
-        try writer.writeBytesNTimes("-", c);
+        try writer.splatBytesAll("-", c);
         try writer.writeAll("^");
         try writer.writeAll(self.contextAfter(1));
 
@@ -110,7 +110,7 @@ pub const Render = struct {
         }
     }
 
-    pub fn format(self: *const Render, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: *const Render, writer: *std.Io.Writer) !void {
         if (self.err) |se| {
             try writer.writeAll(@errorName(se));
             try writer.writeAll(" - ");

--- a/src/error_report.zig
+++ b/src/error_report.zig
@@ -74,10 +74,10 @@ pub const Compile = struct {
         var i: usize = 0;
         const src = self.src;
 
-        while (i <= line_count) : ( i += 1) {
+        while (i <= line_count) : (i += 1) {
             pos = std.mem.lastIndexOfScalar(u8, src[0..pos], '\n') orelse return src[0..end];
         }
-        return src[pos+1..end];
+        return src[pos + 1 .. end];
     }
 
     pub fn contextAfter(self: *const Compile, line_count: usize) []const u8 {
@@ -91,11 +91,11 @@ pub const Compile = struct {
 
         var pos = start;
         var i: usize = 0;
-        while (i <= line_count) : ( i += 1) {
+        while (i <= line_count) : (i += 1) {
             pos = std.mem.indexOfScalarPos(u8, src, pos, '\n') orelse return src[start..];
             pos += 1;
         }
-        return src[start..pos - 1];
+        return src[start .. pos - 1];
     }
 };
 

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -4,7 +4,7 @@ const Allocator = std.mem.Allocator;
 
 pub const Scanner = struct {
     // currently only used for unescaping strings
-    scratch: std.ArrayListUnmanaged(u8),
+    scratch: std.ArrayList(u8),
 
     // where in src we are
     pos: u32 = 0,
@@ -19,7 +19,7 @@ pub const Scanner = struct {
         return .{
             .src = src,
             .arena = arena,
-            .scratch = .{},
+            .scratch = .empty,
         };
     }
 
@@ -410,13 +410,13 @@ pub const Token = union(enum) {
     VAR,
     WHILE,
 
-    pub fn format(self: Token, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: Token, writer: *std.Io.Writer) !void {
         switch (self) {
             .AND => return writer.writeAll("and"),
             .BANG => return writer.writeAll("!"),
             .BANG_EQUAL => return writer.writeAll("!="),
             .BOF => return writer.writeAll("<bof>"),
-            .BOOLEAN => |v| try std.fmt.format(writer, "boolean '{any}'", .{v}),
+            .BOOLEAN => |v| try writer.print("boolean '{any}'", .{v}),
             .BREAK => return writer.writeAll("break"),
             .COLON => return writer.writeAll("colon"),
             .COMMA => return writer.writeAll("comma"),
@@ -427,15 +427,15 @@ pub const Token = union(enum) {
             .EOF => return writer.writeAll("<eof>"),
             .EQUAL => return writer.writeAll("="),
             .EQUAL_EQUAL => return writer.writeAll("=="),
-            .FLOAT => |v| try std.fmt.format(writer, "float '{d}'", .{v}),
+            .FLOAT => |v| try writer.print("float '{d}'", .{v}),
             .FN => return writer.writeAll("fn"),
             .FOR => return writer.writeAll("for"),
             .FOREACH => return writer.writeAll("foreach"),
             .GREATER => return writer.writeAll(">"),
             .GREATER_EQUAL => return writer.writeAll(">="),
-            .IDENTIFIER => |v| try std.fmt.format(writer, "identifier '{s}'", .{v}),
+            .IDENTIFIER => |v| try writer.print("identifier '{s}'", .{v}),
             .IF => return writer.writeAll("if"),
-            .INTEGER => |v| try std.fmt.format(writer, "integer '{any}'", .{v}),
+            .INTEGER => |v| try writer.print("integer '{any}'", .{v}),
             .LEFT_BRACE => return writer.writeAll("{"),
             .LEFT_BRACKET => return writer.writeAll("["),
             .LEFT_PARENTHESIS => return writer.writeAll("("),
@@ -464,7 +464,7 @@ pub const Token = union(enum) {
             .SEMICOLON => return writer.writeAll(";"),
             .SLASH => return writer.writeAll("\\"),
             .STAR => return writer.writeAll("*"),
-            .STRING => |v| try std.fmt.format(writer, "string '{s}'", .{v}),
+            .STRING => |v| try writer.print("string '{s}'", .{v}),
             .VAR => return writer.writeAll("var"),
             .WHILE => return writer.writeAll("while"),
         }
@@ -481,12 +481,10 @@ pub const Error = error {
     IdentifierTooLong
 };
 
-pub fn asUint(comptime string: anytype) @Type(std.builtin.Type{
-    .int = .{
-        .bits = @bitSizeOf(@TypeOf(string.*)) - 8, // (- 8) to exclude sentinel 0
-        .signedness = .unsigned,
-    },
-}) {
+pub fn asUint(comptime string: anytype) @Int(
+    .unsigned,
+    @bitSizeOf(@TypeOf(string.*)) - 8, // (- 8) to exclude sentinel 0
+) {
     const byteLength = @bitSizeOf(@TypeOf(string.*)) / 8 - 1;
     const expectedType = *const [byteLength:0]u8;
     if (@TypeOf(string) != expectedType) {

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -23,14 +23,13 @@ pub const Scanner = struct {
         };
     }
 
-
     pub fn reset(self: *Scanner, src: []const u8) void {
         self.src = src;
         self.pos = 0;
         self.scratch.clearRetainingCapacity();
     }
 
-   // Used by our caller to figure out the position of the next token
+    // Used by our caller to figure out the position of the next token
     // might as well use this opportunity to skip the whitespace with respect
     // to our self.pos;
     pub fn skipSpaces(self: *Scanner) u32 {
@@ -57,60 +56,60 @@ pub const Scanner = struct {
             const start = pos;
             pos += 1;
             switch (b) {
-                '{' => return .{.LEFT_BRACE = {}},
-                '}' => return .{.RIGHT_BRACE = {}},
-                '[' => return .{.LEFT_BRACKET = {}},
-                ']' => return .{.RIGHT_BRACKET = {}},
-                '(' => return .{.LEFT_PARENTHESIS = {}},
-                ')' => return .{.RIGHT_PARENTHESIS = {}},
-                '|' => return .{.PIPE = {}},
-                ',' => return .{.COMMA = {}},
-                '.' => return .{.DOT = {}},
-                '$' => return .{.DOLLAR = {}},
-                '?' => return .{.QUESTION_MARK = {}},
+                '{' => return .{ .LEFT_BRACE = {} },
+                '}' => return .{ .RIGHT_BRACE = {} },
+                '[' => return .{ .LEFT_BRACKET = {} },
+                ']' => return .{ .RIGHT_BRACKET = {} },
+                '(' => return .{ .LEFT_PARENTHESIS = {} },
+                ')' => return .{ .RIGHT_PARENTHESIS = {} },
+                '|' => return .{ .PIPE = {} },
+                ',' => return .{ .COMMA = {} },
+                '.' => return .{ .DOT = {} },
+                '$' => return .{ .DOLLAR = {} },
+                '?' => return .{ .QUESTION_MARK = {} },
                 '%' => switch (self.at(pos)) {
                     '{' => {
                         pos += 1;
-                        return .{.PERCENT_BRACE = {}};
+                        return .{ .PERCENT_BRACE = {} };
                     },
                     '>' => {
                         pos += 1;
-                        return .{.PERCENT_GREATER = {}};
+                        return .{ .PERCENT_GREATER = {} };
                     },
-                    else => return .{.PERCENT = {}},
+                    else => return .{ .PERCENT = {} },
                 },
                 '+' => {
                     if (self.at(pos) == '+') {
                         pos += 1;
-                        return .{.PLUS_PLUS = {}};
+                        return .{ .PLUS_PLUS = {} };
                     }
                     if (self.at(pos) == '=') {
                         pos += 1;
-                        return .{.PLUS_EQUAL = {}};
+                        return .{ .PLUS_EQUAL = {} };
                     }
-                    return .{.PLUS = {}};
+                    return .{ .PLUS = {} };
                 },
                 '-' => {
                     if (self.at(pos) == '-') {
                         pos += 1;
-                        return .{.MINUS_MINUS = {}};
+                        return .{ .MINUS_MINUS = {} };
                     }
                     if (self.at(pos) == '=') {
                         pos += 1;
-                        return .{.MINUS_EQUAL = {}};
+                        return .{ .MINUS_EQUAL = {} };
                     }
                     if (self.at(pos) == '%' and self.at(pos + 1) == '>') {
                         pos += 2;
-                        return .{.MINUS_PERCENT_GREATER = {}};
+                        return .{ .MINUS_PERCENT_GREATER = {} };
                     }
-                    return .{.MINUS = {}};
+                    return .{ .MINUS = {} };
                 },
-                ':' => return .{.COLON = {}},
-                '*' => return .{.STAR = {}},
-                ';' => return .{.SEMICOLON = {}},
+                ':' => return .{ .COLON = {} },
+                '*' => return .{ .STAR = {} },
+                ';' => return .{ .SEMICOLON = {} },
                 '/' => {
                     if (self.at(pos) != '/') {
-                        return .{.SLASH = {}};
+                        return .{ .SLASH = {} };
                     }
                     while (pos < src.len) {
                         if (src[pos] != '\n') {
@@ -125,34 +124,34 @@ pub const Scanner = struct {
                 '!' => {
                     if (self.at(pos) == '=') {
                         pos += 1;
-                        return .{.BANG_EQUAL = {}};
+                        return .{ .BANG_EQUAL = {} };
                     }
-                    return .{.BANG = {}};
+                    return .{ .BANG = {} };
                 },
                 '=' => {
                     if (self.at(pos) == '=') {
                         pos += 1;
-                        return .{.EQUAL_EQUAL = {}};
+                        return .{ .EQUAL_EQUAL = {} };
                     }
-                    return .{.EQUAL = {}};
+                    return .{ .EQUAL = {} };
                 },
                 '>' => {
                     if (self.at(pos) == '=') {
                         pos += 1;
-                        return .{.GREATER_EQUAL = {}};
+                        return .{ .GREATER_EQUAL = {} };
                     }
-                    return .{.GREATER = {}};
+                    return .{ .GREATER = {} };
                 },
                 '<' => switch (self.at(pos)) {
                     '=' => {
                         pos += 1;
-                        return .{.LESSER_EQUAL = {}};
+                        return .{ .LESSER_EQUAL = {} };
                     },
                     '%' => {
                         pos += 1;
-                        return .{.LESSER_PERCENT = {}};
+                        return .{ .LESSER_PERCENT = {} };
                     },
-                    else => return .{.LESSER = {}},
+                    else => return .{ .LESSER = {} },
                 },
                 '0'...'9' => return self.number(&pos),
                 '"' => return self.string('"', &pos),
@@ -160,7 +159,7 @@ pub const Scanner = struct {
                 '`' => {
                     const end = std.mem.indexOfScalarPos(u8, src, pos, '`') orelse return error.UnterminatedString;
                     pos = @intCast(end + 1);
-                    return .{.STRING = src[start + 1 .. end]};
+                    return .{ .STRING = src[start + 1 .. end] };
                 },
                 'a'...'z', 'A'...'Z', '_', '@' => {
                     if (try self.identifier(&pos)) |token| {
@@ -173,7 +172,7 @@ pub const Scanner = struct {
             }
         }
 
-        return .{.EOF = {}};
+        return .{ .EOF = {} };
     }
 
     pub fn peek(self: *Scanner) Token {
@@ -250,7 +249,7 @@ pub const Scanner = struct {
             literal = try allocator.dupe(u8, scratch.items);
         }
 
-        return .{.STRING = literal};
+        return .{ .STRING = literal };
     }
 
     // scanner_pos points to the first byte after whatever byte triggered this
@@ -305,40 +304,40 @@ pub const Scanner = struct {
 
         switch (value.len) {
             2 => switch (@as(u16, @bitCast(value[0..2].*))) {
-                asUint("fn") => return .{.FN = {}},
-                asUint("if") => return .{.IF = {}},
-                asUint("or") => return .{.OR = {}},
+                asUint("fn") => return .{ .FN = {} },
+                asUint("if") => return .{ .IF = {} },
+                asUint("or") => return .{ .OR = {} },
                 else => {},
             },
             3 => switch (@as(u24, @bitCast(value[0..3].*))) {
-                asUint("var") => return .{.VAR = {}},
-                asUint("and") => return .{.AND = {}},
-                asUint("for") => return .{.FOR = {}},
+                asUint("var") => return .{ .VAR = {} },
+                asUint("and") => return .{ .AND = {} },
+                asUint("for") => return .{ .FOR = {} },
                 else => {},
             },
             4 => switch (@as(u32, @bitCast(value[0..4].*))) {
-                asUint("else") => return .{.ELSE = {}},
-                asUint("null") => return .{.NULL = {}},
-                asUint("true") => return .{.BOOLEAN = true},
+                asUint("else") => return .{ .ELSE = {} },
+                asUint("null") => return .{ .NULL = {} },
+                asUint("true") => return .{ .BOOLEAN = true },
                 else => {},
             },
             5 => switch (@as(u40, @bitCast(value[0..5].*))) {
-                asUint("false") => return .{.BOOLEAN = false},
-                asUint("while") => return .{.WHILE = {}},
-                asUint("break") => return .{.BREAK = {}},
+                asUint("false") => return .{ .BOOLEAN = false },
+                asUint("while") => return .{ .WHILE = {} },
+                asUint("break") => return .{ .BREAK = {} },
                 else => {},
             },
             6 => switch (@as(u48, @bitCast(value[0..6].*))) {
-                asUint("return") => return .{.RETURN = {}},
-                asUint("orelse") => return .{.ORELSE = {}},
+                asUint("return") => return .{ .RETURN = {} },
+                asUint("orelse") => return .{ .ORELSE = {} },
                 else => {},
             },
             7 => switch (@as(u56, @bitCast(value[0..7].*))) {
-                asUint("foreach") => return .{.FOREACH = {}},
+                asUint("foreach") => return .{ .FOREACH = {} },
                 else => {},
             },
             8 => switch (@as(u64, @bitCast(value[0..8].*))) {
-                asUint("continue") => return .{.CONTINUE = {}},
+                asUint("continue") => return .{ .CONTINUE = {} },
                 else => {},
             },
             else => {},
@@ -349,7 +348,7 @@ pub const Scanner = struct {
             return error.IdentifierTooLong;
         }
 
-        return .{.IDENTIFIER = value};
+        return .{ .IDENTIFIER = value };
     }
 };
 
@@ -471,15 +470,7 @@ pub const Token = union(enum) {
     }
 };
 
-pub const Error = error {
-    OutOfMemory,
-    UnterminatedString,
-    UnexpectedCharacter,
-    InvalidFloat,
-    InvalidInteger,
-    InvalidEscapeSequence,
-    IdentifierTooLong
-};
+pub const Error = error{ OutOfMemory, UnterminatedString, UnexpectedCharacter, InvalidFloat, InvalidInteger, InvalidEscapeSequence, IdentifierTooLong };
 
 pub fn asUint(comptime string: anytype) @Int(
     .unsigned,

--- a/src/t.zig
+++ b/src/t.zig
@@ -19,7 +19,7 @@ pub fn reset() void {
 
 pub fn createListRef(values: []Value) Value {
     const ref = arena.allocator().create(Value.Ref) catch unreachable;
-    ref.* = .{ .value = .{ .list = .{ .items = values, .capacity = 0 } } };
+    ref.* = .{ .value = .{ .list = .fromOwnedSlice(values) } };
     return .{ .ref = ref };
 }
 

--- a/src/t.zig
+++ b/src/t.zig
@@ -19,7 +19,7 @@ pub fn reset() void {
 
 pub fn createListRef(values: []Value) Value {
     const ref = arena.allocator().create(Value.Ref) catch unreachable;
-    ref.* = .{ .value = .{ .list = .{ .items = values } } };
+    ref.* = .{ .value = .{ .list = .{ .items = values, .capacity = 0 } } };
     return .{ .ref = ref };
 }
 

--- a/src/template.zig
+++ b/src/template.zig
@@ -490,14 +490,18 @@ fn testTemplateWithApp(comptime App: type, app: App, expected: []const u8, templ
     };
     // try tmpl.disassemble(std.io.getStdErr().writer());
 
-    var buf = std.ArrayList(u8).init(t.allocator);
-    defer buf.deinit();
-    tmpl.render(buf.writer(), args, .{}) catch |err| {
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
+    tmpl.render(&aw.writer, args, .{}) catch |err| {
         std.debug.print("==disassemble==\n", .{});
-        try tmpl.disassemble(std.io.getStdErr().writer());
+        var stderr_lock = std.debug.lockStderr(&.{});
+        defer std.debug.unlockStderr();
+
+        const stderr = stderr_lock.terminal().writer;
+        try tmpl.disassemble(stderr);
         return err;
     };
-    try t.expectString(expected, buf.items);
+    try t.expectString(expected, aw.written());
 }
 
 fn testTemplateError(expected: []const u8, template: []const u8) !void {
@@ -538,11 +542,11 @@ fn testTemplateFullError(expected: []const u8, template: []const u8) !void {
 
     var error_report = CompileErrorReport{};
     tmpl.compile(template, .{.error_report = &error_report}) catch {
-        var buf: std.ArrayListUnmanaged(u8) = .{};
-        defer buf.deinit(t.allocator);
+        var aw: std.Io.Writer.Allocating = .init(t.allocator);
+        defer aw.deinit();
 
-        try std.fmt.format(buf.writer(t.allocator), "{}", .{error_report});
-        try t.expectString(expected, buf.items);
+        try aw.writer.print("{f}", .{error_report});
+        try t.expectString(expected, aw.written());
         return;
     };
     return error.NoError;
@@ -553,11 +557,11 @@ fn testTemplateRenderError(expected: []const u8, template: []const u8, args: any
     defer tmpl.deinit();
     try tmpl.compile(template, .{});
 
-    var buf = std.ArrayList(u8).init(t.allocator);
-    defer buf.deinit();
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
 
     var report = RenderErrorReport{};
-    tmpl.render(buf.writer(), args, .{ .error_report = &report }) catch {
+    tmpl.render(&aw.writer, args, .{ .error_report = &report }) catch {
         defer report.deinit();
         try t.expectString(expected, report.message);
         return;

--- a/src/template.zig
+++ b/src/template.zig
@@ -304,13 +304,13 @@ test "Template: semicolon" {
     try testTemplate("Simple1",
         \\<% var x = "Simple1"; -%>
         \\<%= x %>
-   , .{});
+    , .{});
 
     // allow semicolon to be omitted on a closing tag
     try testTemplate("Simple2",
         \\<% var x = "Simple2" -%>
         \\<%= x %>
-   , .{});
+    , .{});
 
     try testTemplate("Simple3", "<%= `Simple3`; %>", .{});
     try testTemplate("Simple4", "<%= `Simple4` %>", .{});
@@ -322,7 +322,7 @@ test "Template: global in function" {
         \\   return @count + n;
         \\ } %>
         \\<%-= add(3) %>
-   , .{.count = 4});
+    , .{ .count = 4 });
 }
 
 test "Template: string concatenation" {
@@ -337,19 +337,19 @@ test "Template: string concatenation" {
     try testTemplate("3 world", "<%-= 3.toString() + ' ' + 'world' %>", .{});
     try testTemplate("true world", "<%-= true.toString() + ' ' + 'world' %>", .{});
 
-    try testTemplate("over 9000!!", "<%-= @a  +' ' + @b + `!!` %>", .{.a = "over", .b = 9000});
+    try testTemplate("over 9000!!", "<%-= @a  +' ' + @b + `!!` %>", .{ .a = "over", .b = 9000 });
 }
 
 test "Template: @include" {
     try testTemplate("included_1",
         \\<% @include("incl_1") %>
-   , .{});
+    , .{});
 
     try testTemplate("included_1,included_1,",
         \\<% for (var i = 0; i < 2; i++) { -%>
         \\ <% @include("incl_1") %>,
         \\<%- } %>
-   , .{});
+    , .{});
 
     try testTemplate("included:2", "<% @include('incl_2') %>", .{});
 
@@ -395,17 +395,16 @@ test "Template: multiple index get" {
     }
 
     {
-
         const UserOptions = struct {
             name: []const u8,
             description: []const u8,
-            @"type": []const u8,
+            type: []const u8,
         };
 
         const globals = .{
             .report = .{
                 .user_options = [_]UserOptions{
-                    .{.name = "Leto", .description = "Worm", .type = "atreides"},
+                    .{ .name = "Leto", .description = "Worm", .type = "atreides" },
                 },
             },
         };
@@ -422,7 +421,7 @@ test "Template: multiple index get" {
             \\<% foreach (@zbs["report"]["user_options"]) |user_option| { %>
             \\# -D<%= user_option %>]
             \\<%- } %>
-        , .{.zbs = globals});
+        , .{ .zbs = globals });
     }
 }
 
@@ -457,19 +456,19 @@ fn testTemplate(expected: []const u8, template: []const u8, args: anytype) !void
             _ = template_key;
 
             if (std.mem.eql(u8, include_key, "incl_1")) {
-                return .{.src = "<%= `included_1` %>"};
+                return .{ .src = "<%= `included_1` %>" };
             }
 
             if (std.mem.eql(u8, include_key, "incl_2")) {
-                return .{.src = "included:2"};
+                return .{ .src = "included:2" };
             }
 
             if (std.mem.eql(u8, include_key, "incl_arg_1")) {
-                return .{.src = "include <%= @value %>"};
+                return .{ .src = "include <%= @value %>" };
             }
 
             if (std.mem.eql(u8, include_key, "incl_arg_2")) {
-                return .{.src = "<% var x = 'incl_local' %> include <%= x %> <%= @value %>"};
+                return .{ .src = "<% var x = 'incl_local' %> include <%= x %> <%= @value %>" };
             }
 
             return null;
@@ -484,8 +483,8 @@ fn testTemplateWithApp(comptime App: type, app: App, expected: []const u8, templ
     defer tmpl.deinit();
 
     var error_report = CompileErrorReport{};
-    tmpl.compile(template, .{.error_report = &error_report}) catch |err| {
-        std.debug.print("Compile template error:\n{}\n", .{error_report});
+    tmpl.compile(template, .{ .error_report = &error_report }) catch |err| {
+        std.debug.print("Compile template error:\n{f}\n", .{error_report});
         return err;
     };
     // try tmpl.disassemble(std.io.getStdErr().writer());
@@ -509,7 +508,7 @@ fn testTemplateError(expected: []const u8, template: []const u8) !void {
     defer tmpl.deinit();
 
     var error_report = CompileErrorReport{};
-    tmpl.compile(template, .{.error_report = &error_report}) catch {
+    tmpl.compile(template, .{ .error_report = &error_report }) catch {
         try t.expectString(expected, error_report.message);
         return;
     };
@@ -523,14 +522,14 @@ fn testTemplateFullError(expected: []const u8, template: []const u8) !void {
             _ = template_key;
 
             if (std.mem.eql(u8, include_key, "incl_err_1")) {
-                return .{.src =
-                    \\ Products:
-                    \\ <% for ; %>
-                };
+                return .{ .src = 
+                \\ Products:
+                \\ <% for ; %>
+            };
             }
 
             if (std.mem.eql(u8, include_key, "incl_err_2")) {
-                return .{.src = "<%="};
+                return .{ .src = "<%=" };
             }
 
             return null;
@@ -541,7 +540,7 @@ fn testTemplateFullError(expected: []const u8, template: []const u8) !void {
     defer tmpl.deinit();
 
     var error_report = CompileErrorReport{};
-    tmpl.compile(template, .{.error_report = &error_report}) catch {
+    tmpl.compile(template, .{ .error_report = &error_report }) catch {
         var aw: std.Io.Writer.Allocating = .init(t.allocator);
         defer aw.deinit();
 

--- a/src/value.zig
+++ b/src/value.zig
@@ -280,7 +280,7 @@ pub const Value = union(enum) {
 
     fn convertForEquality(self: Value) Value {
         if (self == .ref and self.ref.value == .buffer) {
-            return .{.string = self.ref.value.buffer.items};
+            return .{ .string = self.ref.value.buffer.items };
         }
         return self;
     }
@@ -373,7 +373,7 @@ pub const MapIterator = struct {
 fn writeStringEscaped(writer: *std.Io.Writer, value: []const u8) !void {
     var v = value;
     while (v.len > 0) {
-        const index = std.mem.indexOfAnyPos(u8, v, 0, &.{'&', '<', '>', '"', '\''}) orelse {
+        const index = std.mem.indexOfAnyPos(u8, v, 0, &.{ '&', '<', '>', '"', '\'' }) orelse {
             return writer.writeAll(v);
         };
         try writer.writeAll(v[0..index]);
@@ -385,7 +385,7 @@ fn writeStringEscaped(writer: *std.Io.Writer, value: []const u8) !void {
             '\'' => try writer.writeAll("&#39;"),
             else => unreachable,
         }
-        v = v[index+1..];
+        v = v[index + 1 ..];
     }
 }
 
@@ -534,17 +534,17 @@ test "writeStringEscaped" {
     var aw: std.Io.Writer.Allocating = .init(t.allocator);
     defer aw.deinit();
 
-    // {
-    //     try writeStringEscaped(&aw.writer, "hello world");
-    //     try t.expectString("hello world", aw.written());
-    //     aw.clearRetainingCapacity();
-    // }
+    {
+        try writeStringEscaped(&aw.writer, "hello world");
+        try t.expectString("hello world", aw.written());
+        aw.clearRetainingCapacity();
+    }
 
-    // {
-    //     try writeStringEscaped(&aw.writer, "<>\"'&");
-    //     try t.expectString("&lt;&gt;&#34;&#39;&amp;", aw.written());
-    //     aw.clearRetainingCapacity();
-    // }
+    {
+        try writeStringEscaped(&aw.writer, "<>\"'&");
+        try t.expectString("&lt;&gt;&#34;&#39;&amp;", aw.written());
+        aw.clearRetainingCapacity();
+    }
 
     {
         try writeStringEscaped(&aw.writer, " < > \" ' & ");

--- a/src/value.zig
+++ b/src/value.zig
@@ -5,9 +5,9 @@ const RefPool = @import("vm.zig").RefPool;
 const Allocator = std.mem.Allocator;
 
 pub const Value = union(enum) {
-    pub const List = std.ArrayListUnmanaged(Value);
-    pub const Buffer = std.ArrayListUnmanaged(u8);
-    pub const Map = std.ArrayHashMapUnmanaged(KeyValue, Value, KeyValue.Context, true);
+    pub const List = std.ArrayList(Value);
+    pub const Buffer = std.ArrayList(u8);
+    pub const Map = std.array_hash_map.Custom(KeyValue, Value, KeyValue.Context, true);
 
     i64: i64,
     f64: f64,
@@ -16,7 +16,7 @@ pub const Value = union(enum) {
     ref: *Ref,
     string: []const u8,
 
-    pub fn format(self: Value, _: []const u8, _: anytype, writer: anytype) !void {
+    pub fn format(self: Value, writer: *std.Io.Writer) !void {
         return self.write(writer, false);
     }
 
@@ -32,11 +32,11 @@ pub const Value = union(enum) {
         },
     };
 
-    pub fn write(self: Value, writer: anytype, escape: bool) !void {
+    pub fn write(self: Value, writer: *std.Io.Writer, escape: bool) !void {
         switch (self) {
-            .i64 => |v| return std.fmt.formatInt(v, 10, .lower, .{}, writer),
+            .i64 => |v| return writer.printInt(v, 10, .lower, .{}),
             .bool => |v| return writer.writeAll(if (v) "true" else "false"),
-            .f64 => |v| return std.fmt.format(writer, "{d}", .{v}),
+            .f64 => |v| return writer.print("{d}", .{v}),
             .null => return writer.writeAll("null"),
             .string => |v| if (escape) try writeStringEscaped(writer, v) else try writer.writeAll(v),
             .ref => |ref| switch (ref.value) {
@@ -290,13 +290,13 @@ pub const KeyValue = union(enum) {
     i64: i64,
     string: []const u8,
 
-    pub fn format(self: KeyValue, _: []const u8, _: anytype, writer: anytype) !void {
+    pub fn format(self: KeyValue, writer: *std.Io.Writer) !void {
         return self.write(writer, false);
     }
 
-    pub fn write(self: KeyValue, writer: anytype, escape: bool) !void {
+    pub fn write(self: KeyValue, writer: *std.Io.Writer, escape: bool) !void {
         switch (self) {
-            .i64 => |v| return std.fmt.formatInt(v, 10, .lower, .{}, writer),
+            .i64 => |v| return writer.printInt(v, 10, .lower, .{}),
             .string => |v| if (escape) try writeStringEscaped(writer, v) else try writer.writeAll(v),
         }
     }
@@ -370,7 +370,7 @@ pub const MapIterator = struct {
     ref: *Value.Ref, // the Value.Ref of the map, which we need to deference when the iterator goes out of scope
 };
 
-fn writeStringEscaped(writer: anytype, value: []const u8) !void {
+fn writeStringEscaped(writer: *std.Io.Writer, value: []const u8) !void {
     var v = value;
     while (v.len > 0) {
         const index = std.mem.indexOfAnyPos(u8, v, 0, &.{'&', '<', '>', '"', '\''}) orelse {
@@ -531,34 +531,34 @@ test "Value: equal" {
 }
 
 test "writeStringEscaped" {
-    var buf = std.ArrayList(u8).init(t.allocator);
-    defer buf.deinit();
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
 
     // {
-    //     try writeStringEscaped(buf.writer(), "hello world");
-    //     try t.expectString("hello world", buf.items);
-    //     buf.clearRetainingCapacity();
+    //     try writeStringEscaped(&aw.writer, "hello world");
+    //     try t.expectString("hello world", aw.written());
+    //     aw.clearRetainingCapacity();
     // }
 
     // {
-    //     try writeStringEscaped(buf.writer(), "<>\"'&");
-    //     try t.expectString("&lt;&gt;&#34;&#39;&amp;", buf.items);
-    //     buf.clearRetainingCapacity();
+    //     try writeStringEscaped(&aw.writer, "<>\"'&");
+    //     try t.expectString("&lt;&gt;&#34;&#39;&amp;", aw.written());
+    //     aw.clearRetainingCapacity();
     // }
 
     {
-        try writeStringEscaped(buf.writer(), " < > \" ' & ");
-        try t.expectString(" &lt; &gt; &#34; &#39; &amp; ", buf.items);
-        buf.clearRetainingCapacity();
+        try writeStringEscaped(&aw.writer, " < > \" ' & ");
+        try t.expectString(" &lt; &gt; &#34; &#39; &amp; ", aw.written());
+        aw.clearRetainingCapacity();
     }
 }
 
 fn assertFormat(expected: []const u8, value: Value) !void {
-    var arr = std.ArrayList(u8).init(t.allocator);
-    defer arr.deinit();
+    var aw: std.Io.Writer.Allocating = .init(t.allocator);
+    defer aw.deinit();
 
-    try std.fmt.format(arr.writer(), "{}", .{value});
-    try t.expectString(expected, arr.items);
+    try aw.writer.print("{f}", .{value});
+    try t.expectString(expected, aw.written());
 }
 
 fn assertEqual(expected: bool, left: Value, right: Value) !void {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -39,14 +39,14 @@ pub fn VM(comptime App: type) type {
         pub fn init(allocator: Allocator, app: App) Self {
             return .{
                 .app = app,
+                ._ref_pool = .empty,
                 ._allocator = allocator,
-                ._ref_pool = RefPool.init(allocator),
             };
         }
 
         // See template.zig's hack around globals to see why we're doing this
         pub fn prepareForGlobals(self: *Self, count: usize) !void {
-            return self._globals.appendNTimes(self._allocator, .{.null = {}}, count);
+            return self._globals.appendNTimes(self._allocator, .{ .null = {} }, count);
         }
 
         pub fn injectGlobal(self: *Self, value: Value, i: usize) void {
@@ -97,7 +97,6 @@ pub fn VM(comptime App: type) type {
             var stack = &self._stack;
             var globals = &self._globals;
             var frame_pointer: usize = 0;
-
 
             while (true) {
                 const op_code: OpCode = @enumFromInt(ip[0]);
@@ -276,7 +275,7 @@ pub fn VM(comptime App: type) type {
 
                         const iterator_start = items.len - value_count;
                         ITERATE: for (items[iterator_start..len]) |it| {
-                            const value = (try iterateNext(ref_pool, it.ref)) orelse {
+                            const value = (try iterateNext(self._allocator, ref_pool, it.ref)) orelse {
                                 stack.appendAssumeCapacity(.{ .bool = false });
                                 break :ITERATE;
                             };
@@ -323,7 +322,7 @@ pub fn VM(comptime App: type) type {
                                 const value_count: u32 = @bitCast(ip[0..4].*);
                                 ip += 4;
 
-                                var ref = try ref_pool.create();
+                                var ref = try ref_pool.create(allocator);
                                 ref.* = .{ .value = .{ .list = .empty } };
                                 var list = &ref.value.list;
 
@@ -347,7 +346,7 @@ pub fn VM(comptime App: type) type {
                                 const entry_count: u32 = @bitCast(ip[0..4].*);
                                 ip += 4;
 
-                                var ref = try ref_pool.create();
+                                var ref = try ref_pool.create(allocator);
                                 ref.* = .{ .value = .{ .map = .{} } };
                                 var map = &ref.value.map;
 
@@ -1100,12 +1099,12 @@ pub fn VM(comptime App: type) type {
             switch (value) {
                 .ref => |ref| switch (ref.value) {
                     .list => |*list| {
-                        const new_ref = try ref_pool.create();
+                        const new_ref = try ref_pool.create(self._allocator);
                         new_ref.* = .{ .value = .{ .list_iterator = .{ .index = 0, .list = list, .ref = ref } } };
                         return .{ .ref = new_ref };
                     },
                     .map => |map| {
-                        const new_ref = try ref_pool.create();
+                        const new_ref = try ref_pool.create(self._allocator);
                         new_ref.* = .{ .value = .{ .map_iterator = .{ .inner = map.iterator(), .ref = ref } } };
                         return .{ .ref = new_ref };
                     },
@@ -1117,7 +1116,7 @@ pub fn VM(comptime App: type) type {
             return error.TypeError;
         }
 
-        fn iterateNext(ref_pool: *RefPool, ref: *Value.Ref) !?Value {
+        fn iterateNext(allocator: Allocator, ref_pool: *RefPool, ref: *Value.Ref) !?Value {
             switch (ref.value) {
                 .list_iterator => |*it| {
                     const index = it.index;
@@ -1130,7 +1129,7 @@ pub fn VM(comptime App: type) type {
                 },
                 .map_iterator => |*it| {
                     const entry = it.inner.next() orelse return null;
-                    const new_ref = try ref_pool.create();
+                    const new_ref = try ref_pool.create(allocator);
                     new_ref.* = .{ .value = .{ .map_entry = entry } };
                     return .{ .ref = new_ref };
                 },
@@ -1147,7 +1146,7 @@ pub fn VM(comptime App: type) type {
         }
 
         pub fn createRef(self: *Self) !*Value.Ref {
-            return self._ref_pool.create();
+            return self._ref_pool.create(self._allocator);
         }
 
         pub fn acquire(_: *const Self, value: Value) void {
@@ -1173,7 +1172,6 @@ pub fn VM(comptime App: type) type {
         }
 
         fn releaseCount(self: *Self, stack: *Stack, n: usize) void {
-
             const items = stack.items;
             const current_len = items.len;
             std.debug.assert(current_len >= n);
@@ -1207,7 +1205,6 @@ pub fn VM(comptime App: type) type {
                         for (list.items) |value| {
                             self.release(value);
                         }
-
                     }
                     list.deinit(self._allocator);
                 },
@@ -1263,7 +1260,8 @@ pub fn VM(comptime App: type) type {
                         },
                         else => return self.createValue(zig.*),
                     }
-                    .many, .slice => {
+                        .many,
+                    .slice => {
                         if (ptr.size == .many and ptr.sentinel_ptr == null) {
                             return error.UnsupportedType;
                         }
@@ -1382,22 +1380,19 @@ const Frame = struct {
 const DebugRefPool = struct {
     count: usize,
     pool: std.heap.MemoryPool(Value.Ref),
-    allocator: Allocator,
 
-    fn init(allocator: Allocator) DebugRefPool {
-        return .{
-            .count = 0,
-            .pool = .empty,
-            .allocator = allocator,
-        };
-    }
-    fn deinit(self: *DebugRefPool) void {
-        self.pool.deinit(self.allocator);
+    pub const empty = DebugRefPool{
+        .count = 0,
+        .pool = .empty,
+    };
+
+    fn deinit(self: *DebugRefPool, allocator: Allocator) void {
+        self.pool.deinit(allocator);
     }
 
-    pub fn create(self: *DebugRefPool) !*Value.Ref {
+    pub fn create(self: *DebugRefPool, allocator: Allocator) !*Value.Ref {
         self.count += 1;
-        return self.pool.create(self.allocator);
+        return self.pool.create(allocator);
     }
 
     pub fn destroy(self: *DebugRefPool, ref: *Value.Ref) void {

--- a/src/vm.zig
+++ b/src/vm.zig
@@ -10,7 +10,7 @@ const VERSION = @import("byte_code.zig").VERSION;
 
 const Allocator = std.mem.Allocator;
 
-const Stack = std.ArrayListUnmanaged(Value);
+const Stack = std.ArrayList(Value);
 
 pub const RefPool = if (builtin.is_test) DebugRefPool else std.heap.MemoryPool(Value.Ref);
 
@@ -23,8 +23,8 @@ pub fn VM(comptime App: type) type {
         _allocator: Allocator,
         _ref_pool: RefPool,
 
-        _stack: Stack = .{},
-        _globals: Stack = .{},
+        _stack: Stack = .empty,
+        _globals: Stack = .empty,
 
         _frames: [MAX_CALL_FRAMES]Frame = undefined,
 
@@ -214,7 +214,7 @@ pub fn VM(comptime App: type) type {
                             .i64 => |n| v.i64 = -n,
                             .f64 => |n| v.f64 = -n,
                             else => {
-                                try self.setErrorFmt("Cannot negate non-numeric value: -{s}", .{v.*});
+                                try self.setErrorFmt("Cannot negate non-numeric value: -{f}", .{v.*});
                                 return error.TypeError;
                             },
                         }
@@ -224,7 +224,7 @@ pub fn VM(comptime App: type) type {
                         switch (v.*) {
                             .bool => |b| v.bool = !b,
                             else => {
-                                try self.setErrorFmt("Cannot inverse non-boolean value: !{s}", .{v.*});
+                                try self.setErrorFmt("Cannot inverse non-boolean value: !{f}", .{v.*});
                                 return error.TypeError;
                             },
                         }
@@ -324,7 +324,7 @@ pub fn VM(comptime App: type) type {
                                 ip += 4;
 
                                 var ref = try ref_pool.create();
-                                ref.* = .{ .value = .{ .list = .{} } };
+                                ref.* = .{ .value = .{ .list = .empty } };
                                 var list = &ref.value.list;
 
                                 if (value_count == 0) {
@@ -511,9 +511,10 @@ pub fn VM(comptime App: type) type {
                             const start_index = items.len - arity;
 
                             {
-                                std.debug.lockStdErr();
-                                defer std.debug.unlockStdErr();
-                                const stderr = std.io.getStdErr().writer();
+                                var stderr_lock = std.debug.lockStderr(&.{});
+                                defer std.debug.unlockStderr();
+
+                                const stderr = stderr_lock.terminal().writer;
                                 try items[start_index].write(stderr, false);
                                 for (items[start_index + 1 ..]) |value| {
                                     try stderr.writeAll(" ");
@@ -587,9 +588,15 @@ pub fn VM(comptime App: type) type {
                     else => {},
                 },
                 .string => |l| {
-                    var buffer = Value.Buffer{};
+                    var buffer: Value.Buffer = .empty;
                     try buffer.appendSlice(self._allocator, l);
-                    try right.write(buffer.writer(self._allocator), false);
+                    {
+                        var aw: std.Io.Writer.Allocating = .fromArrayList(self._allocator, &buffer);
+                        defer buffer = aw.toArrayList();
+                        right.write(&aw.writer, false) catch |err| switch (err) {
+                            error.WriteFailed => return error.OutOfMemory, // See ArrayList.print
+                        };
+                    }
 
                     const buffer_ref = try self.createRef();
                     buffer_ref.* = .{ .count = 1, .value = .{ .buffer = buffer } };
@@ -598,13 +605,25 @@ pub fn VM(comptime App: type) type {
                 else => {
                     const allocator = self._allocator;
                     if (left == .ref and left.ref.value == .buffer) {
-                        try right.write(left.ref.value.buffer.writer(allocator), false);
+                        {
+                            var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &left.ref.value.buffer);
+                            defer left.ref.value.buffer = aw.toArrayList();
+                            right.write(&aw.writer, false) catch |err| switch (err) {
+                                error.WriteFailed => return error.OutOfMemory, // See ArrayList.print
+                            };
+                        }
                         return left;
                     }
                     switch (right) {
                         .string => |r| {
-                            var buffer = Value.Buffer{};
-                            try left.write(buffer.writer(allocator), false);
+                            var buffer: Value.Buffer = .empty;
+                            {
+                                var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buffer);
+                                defer buffer = aw.toArrayList();
+                                left.write(&aw.writer, false) catch |err| switch (err) {
+                                    error.WriteFailed => return error.OutOfMemory, // See ArrayList.print
+                                };
+                            }
                             try buffer.appendSlice(allocator, r);
 
                             const buffer_ref = try self.createRef();
@@ -613,8 +632,14 @@ pub fn VM(comptime App: type) type {
                         },
                         .ref => |ref| switch (ref.value) {
                             .buffer => |r| {
-                                var buffer = Value.Buffer{};
-                                try left.write(buffer.writer(allocator), false);
+                                var buffer: Value.Buffer = .empty;
+                                {
+                                    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buffer);
+                                    defer buffer = aw.toArrayList();
+                                    left.write(&aw.writer, false) catch |err| switch (err) {
+                                        error.WriteFailed => return error.OutOfMemory, // See ArrayList.print
+                                    };
+                                }
                                 try buffer.appendSlice(allocator, r.items);
                                 self.releaseRef(ref);
 
@@ -628,7 +653,7 @@ pub fn VM(comptime App: type) type {
                     }
                 },
             }
-            try self.setErrorFmt("Cannot add non-numeric value: {s} + {s}", .{ left, right });
+            try self.setErrorFmt("Cannot add non-numeric value: {f} + {f}", .{ left, right });
             return error.TypeError;
         }
 
@@ -646,7 +671,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Cannot subtract non-numeric value: {s} - {s}", .{ left, right });
+            try self.setErrorFmt("Cannot subtract non-numeric value: {f} - {f}", .{ left, right });
             return error.TypeError;
         }
 
@@ -664,7 +689,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Cannot multiply non-numeric value: {s} - {s}", .{ left, right });
+            try self.setErrorFmt("Cannot multiply non-numeric value: {f} - {f}", .{ left, right });
             return error.TypeError;
         }
 
@@ -682,7 +707,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Cannot divide non-numeric value: {s} - {s}", .{ left, right });
+            try self.setErrorFmt("Cannot divide non-numeric value: {f} - {f}", .{ left, right });
             return error.TypeError;
         }
 
@@ -694,7 +719,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Cannot take remainder of non-integer value: {s} - {s}", .{ left, right });
+            try self.setErrorFmt("Cannot take remainder of non-integer value: {f} - {f}", .{ left, right });
             return error.TypeError;
         }
 
@@ -723,7 +748,7 @@ pub fn VM(comptime App: type) type {
 
         fn equal(self: *Self, left: Value, right: Value) ComparisonError!bool {
             return left.equal(right) catch {
-                try self.setErrorFmt("Incompatible type comparison: {s} == {s} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
+                try self.setErrorFmt("Incompatible type comparison: {f} == {f} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
                 return error.TypeError;
             };
         }
@@ -746,7 +771,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Incompatible type comparison: {s} > {s} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
+            try self.setErrorFmt("Incompatible type comparison: {f} > {f} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
             return error.TypeError;
         }
 
@@ -768,7 +793,7 @@ pub fn VM(comptime App: type) type {
                 },
                 else => {},
             }
-            try self.setErrorFmt("Incompatible type comparison: {s} < {s} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
+            try self.setErrorFmt("Incompatible type comparison: {f} < {f} ({s}, {s})", .{ left, right, left.friendlyName(), right.friendlyName() });
             return error.TypeError;
         }
 
@@ -904,7 +929,7 @@ pub fn VM(comptime App: type) type {
                 .ref => |ref| switch (ref.value) {
                     .map => |*map| {
                         const value = map.getPtr(.{ .string = index }) orelse {
-                            try self.setErrorFmt("Map does not contain key '{d}'", .{index});
+                            try self.setErrorFmt("Map does not contain key '{s}'", .{index});
                             return error.MissingKey;
                         };
                         value.* = try self.add(value.*, incr);
@@ -968,8 +993,14 @@ pub fn VM(comptime App: type) type {
                 if (target == .ref and target.ref.value == .buffer) {
                     return target;
                 }
-                var buffer = Value.Buffer{};
-                try target.write(buffer.writer(allocator), false);
+                var buffer: Value.Buffer = .empty;
+                {
+                    var aw: std.Io.Writer.Allocating = .fromArrayList(self._allocator, &buffer);
+                    defer buffer = aw.toArrayList();
+                    target.write(&aw.writer, false) catch |err| switch (err) {
+                        error.WriteFailed => return error.OutOfMemory, // See ArrayList.print
+                    };
+                }
 
                 const buffer_ref = try self.createRef();
                 buffer_ref.* = .{ .count = 0, .value = .{ .buffer = buffer } };
@@ -1242,7 +1273,7 @@ pub fn VM(comptime App: type) type {
                             return .{ .string = zig };
                         }
 
-                        var list: Value.List = .{};
+                        var list: Value.List = .empty;
                         try list.ensureTotalCapacity(self._allocator, slice.len);
                         for (slice) |v| {
                             list.appendAssumeCapacity(try self.createValue(v));
@@ -1351,20 +1382,22 @@ const Frame = struct {
 const DebugRefPool = struct {
     count: usize,
     pool: std.heap.MemoryPool(Value.Ref),
+    allocator: Allocator,
 
     fn init(allocator: Allocator) DebugRefPool {
         return .{
             .count = 0,
-            .pool = std.heap.MemoryPool(Value.Ref).init(allocator),
+            .pool = .empty,
+            .allocator = allocator,
         };
     }
     fn deinit(self: *DebugRefPool) void {
-        self.pool.deinit();
+        self.pool.deinit(self.allocator);
     }
 
     pub fn create(self: *DebugRefPool) !*Value.Ref {
         self.count += 1;
-        return self.pool.create();
+        return self.pool.create(self.allocator);
     }
 
     pub fn destroy(self: *DebugRefPool, ref: *Value.Ref) void {

--- a/src/ztl.zig
+++ b/src/ztl.zig
@@ -20,30 +20,19 @@ pub fn Functions(comptime A: type) type {
     };
 
     if (App == void or @hasDecl(App, "ZtlFunctions") == false) {
-        return @Type(.{
-            .@"enum" = .{
-                .decls = &.{},
-                .tag_type = u8,
-                .fields = &.{.{ .name = "", .value = 0 }}, // HACK, std.meta.stringToEnum doesn't work on an empty enum, lol what?
-                .is_exhaustive = true,
-            },
-        });
+        return @Enum(u8, .exhaustive, &.{""}, &.{0}); // HACK, std.meta.stringToEnum doesn't work on an empty enum, lol what?
     }
     const declarations = std.meta.declarations(App.ZtlFunctions);
-    var fields: [declarations.len]std.builtin.Type.EnumField = undefined;
+
+    var names: [declarations.len][]const u8 = undefined;
+    var values: [declarations.len]u16 = undefined;
 
     for (declarations, 0..) |d, i| {
-        fields[i] = .{ .name = d.name, .value = i };
+        names[i] = d.name;
+        values[i] = i;
     }
 
-    // the type of the @"enum" tag is std.builtin.Type.Enum
-    // we use the type inference syntax, i.e. .{...}
-    return @Type(.{ .@"enum" = .{
-        .decls = &.{},
-        .tag_type = u16,
-        .fields = &fields,
-        .is_exhaustive = true,
-    } });
+    return @Enum(u16, .exhaustive, &names, &values);
 }
 
 const t = @import("t.zig");

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -1,24 +1,3 @@
-// https://gist.githubusercontent.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/raw/8e82642093d2f4341fb870d18d1fe5b213b2fd11/test_runner.zig
-// This is for the Zig 0.16.
-
-// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/eb15512d6ae49663fa9df6c7a9725b20dab43edd
-// for a version that workson Zig 0.15.2.
-
-// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/1f317ebc9cd09bc50fd5591d09c34255e15d1d85
-// for a version that workson Zig 0.14.1.
-
-// in your build.zig, you can specify a custom test runner:
-// const tests = b.addTest(.{
-//    .root_module = $MODULE_BEING_TESTED,
-//    .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
-// });
-
-// in your build.zig, you can specify a custom test runner:
-// const tests = b.addTest(.{
-//    .root_module = $MODULE_BEING_TESTED,
-//    .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
-// });
-
 const std = @import("std");
 const Io = std.Io;
 const builtin = @import("builtin");
@@ -56,6 +35,8 @@ pub fn main(init: std.process.Init) !void {
 
     Printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
 
+    var after_each: std.ArrayList(std.builtin.TestFn) = .empty;
+
     for (builtin.test_functions) |t| {
         if (isSetup(t)) {
             t.func() catch |err| {
@@ -63,10 +44,13 @@ pub fn main(init: std.process.Init) !void {
                 return err;
             };
         }
+        if (isAfterEach(t)) {
+            try after_each.append(allocator, t);
+        }
     }
 
     for (builtin.test_functions) |t| {
-        if (isSetup(t) or isTeardown(t)) {
+        if (isSetup(t) or isTeardown(t) or isAfterEach(t)) {
             continue;
         }
 
@@ -95,6 +79,11 @@ pub fn main(init: std.process.Init) !void {
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
         const result = t.func();
+
+        for (after_each.items) |ae| {
+            try ae.func();
+        }
+
         current_test = null;
 
         const ns_taken = slowest.endTiming(io, friendly_name);
@@ -305,4 +294,8 @@ fn isSetup(t: std.builtin.TestFn) bool {
 
 fn isTeardown(t: std.builtin.TestFn) bool {
     return std.mem.endsWith(u8, t.name, "tests:afterAll");
+}
+
+fn isAfterEach(t: std.builtin.TestFn) bool {
+    return std.mem.endsWith(u8, t.name, "tests:afterEach");
 }

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -1,16 +1,26 @@
+// https://gist.githubusercontent.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/raw/8e82642093d2f4341fb870d18d1fe5b213b2fd11/test_runner.zig
+// This is for the Zig 0.16.
+
+// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/eb15512d6ae49663fa9df6c7a9725b20dab43edd
+// for a version that workson Zig 0.15.2.
+
+// See https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/1f317ebc9cd09bc50fd5591d09c34255e15d1d85
+// for a version that workson Zig 0.14.1.
+
 // in your build.zig, you can specify a custom test runner:
 // const tests = b.addTest(.{
-//   .root_source_file = b.path("src/main.zig"),
-//   .target = target,
-//   .optimize = optimize,
-//   // Add these lines:
-//   .test_runner = .{
-//       .path = b.path("test_runner.zig"),
-//       .mode = .simple,
-//    },
+//    .root_module = $MODULE_BEING_TESTED,
+//    .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
+// });
+
+// in your build.zig, you can specify a custom test runner:
+// const tests = b.addTest(.{
+//    .root_module = $MODULE_BEING_TESTED,
+//    .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
 // });
 
 const std = @import("std");
+const Io = std.Io;
 const builtin = @import("builtin");
 
 const Allocator = std.mem.Allocator;
@@ -20,16 +30,23 @@ const BORDER = "=" ** 80;
 // use in custom panic handler
 var current_test: ?[]const u8 = null;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var mem: [8192]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&mem);
 
     const allocator = fba.allocator();
 
-    const env = Env.init(allocator);
-    defer env.deinit(allocator);
+    const env = Env.init(init.environ_map);
 
-    var slowest = SlowTracker.init(allocator, 5);
+    std.testing.io_instance = .init(init.gpa, .{
+        .argv0 = .init(init.minimal.args),
+        .environ = init.minimal.environ,
+    });
+    defer std.testing.io_instance.deinit();
+
+    const io = std.testing.io;
+
+    var slowest = SlowTracker.init(allocator, io, 5);
     defer slowest.deinit();
 
     var pass: usize = 0;
@@ -37,33 +54,24 @@ pub fn main() !void {
     var skip: usize = 0;
     var leak: usize = 0;
 
-    try std.posix.getrandom(std.mem.asBytes(&std.testing.random_seed));
-
-    const printer = Printer.init();
-    printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
-
-    var after_each = std.ArrayListUnmanaged(std.builtin.TestFn){};
+    Printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
 
     for (builtin.test_functions) |t| {
         if (isSetup(t)) {
-            current_test = friendlyName(t.name);
             t.func() catch |err| {
-                printer.status(.fail, "\nsetup \"{s}\" failed: {}\n", .{ t.name, err });
+                Printer.status(.fail, "\nsetup \"{s}\" failed: {}\n", .{ t.name, err });
                 return err;
             };
-        }
-        if (isAfterEach(t)) {
-            try after_each.append(allocator, t);
         }
     }
 
     for (builtin.test_functions) |t| {
-        if (isSetup(t) or isTeardown(t) or isAfterEach(t)) {
+        if (isSetup(t) or isTeardown(t)) {
             continue;
         }
 
         var status = Status.pass;
-        slowest.startTiming();
+        slowest.startTiming(io);
 
         const is_unnamed_test = isUnnamed(t);
         if (env.filter) |f| {
@@ -72,26 +80,28 @@ pub fn main() !void {
             }
         }
 
-        const friendly_name = friendlyName(t.name);
+        const friendly_name = blk: {
+            const name = t.name;
+            var it = std.mem.splitScalar(u8, name, '.');
+            while (it.next()) |value| {
+                if (std.mem.eql(u8, value, "test")) {
+                    const rest = it.rest();
+                    break :blk if (rest.len > 0) rest else name;
+                }
+            }
+            break :blk name;
+        };
+
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
         const result = t.func();
-
-        for (after_each.items) |ae| {
-            try ae.func();
-        }
-
         current_test = null;
 
-        if (is_unnamed_test) {
-            continue;
-        }
-
-        const ns_taken = slowest.endTiming(friendly_name);
+        const ns_taken = slowest.endTiming(io, friendly_name);
 
         if (std.testing.allocator_instance.deinit() == .leak) {
             leak += 1;
-            printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });
+            Printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });
         }
 
         if (result) |_| {
@@ -104,9 +114,9 @@ pub fn main() !void {
             else => {
                 status = .fail;
                 fail += 1;
-                printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
+                Printer.status(.fail, "\n{s}\n\"{s}\" - {s}\n{s}\n", .{ BORDER, friendly_name, @errorName(err), BORDER });
                 if (@errorReturnTrace()) |trace| {
-                    std.debug.dumpStackTrace(trace.*);
+                    std.debug.dumpErrorReturnTrace(trace);
                 }
                 if (env.fail_first) {
                     break;
@@ -116,17 +126,16 @@ pub fn main() !void {
 
         if (env.verbose) {
             const ms = @as(f64, @floatFromInt(ns_taken)) / 1_000_000.0;
-            printer.status(status, "{s} ({d:.2}ms)\n", .{ friendly_name, ms });
+            Printer.status(status, "{s} ({d:.2}ms)\n", .{ friendly_name, ms });
         } else {
-            printer.status(status, ".", .{});
+            Printer.status(status, ".", .{});
         }
     }
 
     for (builtin.test_functions) |t| {
         if (isTeardown(t)) {
-            current_test = friendlyName(t.name);
             t.func() catch |err| {
-                printer.status(.fail, "\nteardown \"{s}\" failed: {}\n", .{ t.name, err });
+                Printer.status(.fail, "\nteardown \"{s}\" failed: {}\n", .{ t.name, err });
                 return err;
             };
         }
@@ -134,54 +143,32 @@ pub fn main() !void {
 
     const total_tests = pass + fail;
     const status = if (fail == 0) Status.pass else Status.fail;
-    printer.status(status, "\n{d} of {d} test{s} passed\n", .{ pass, total_tests, if (total_tests != 1) "s" else "" });
+    Printer.status(status, "\n{d} of {d} test{s} passed\n", .{ pass, total_tests, if (total_tests != 1) "s" else "" });
     if (skip > 0) {
-        printer.status(.skip, "{d} test{s} skipped\n", .{ skip, if (skip != 1) "s" else "" });
+        Printer.status(.skip, "{d} test{s} skipped\n", .{ skip, if (skip != 1) "s" else "" });
     }
     if (leak > 0) {
-        printer.status(.fail, "{d} test{s} leaked\n", .{ leak, if (leak != 1) "s" else "" });
+        Printer.status(.fail, "{d} test{s} leaked\n", .{ leak, if (leak != 1) "s" else "" });
     }
-    printer.fmt("\n", .{});
-    try slowest.display(printer);
-    printer.fmt("\n", .{});
-    std.posix.exit(if (fail == 0) 0 else 1);
-}
-
-fn friendlyName(name: []const u8) []const u8 {
-    var it = std.mem.splitScalar(u8, name, '.');
-    while (it.next()) |value| {
-        if (std.mem.eql(u8, value, "test")) {
-            const rest = it.rest();
-            return if (rest.len > 0) rest else name;
-        }
-    }
-    return name;
+    Printer.fmt("\n", .{});
+    try slowest.display();
+    Printer.fmt("\n", .{});
+    std.process.exit(if (fail == 0) 0 else 1);
 }
 
 const Printer = struct {
-    out: std.fs.File.Writer,
-
-    fn init() Printer {
-        return .{
-            .out = std.io.getStdErr().writer(),
-        };
+    fn fmt(comptime format: []const u8, args: anytype) void {
+        std.debug.print(format, args);
     }
 
-    fn fmt(self: Printer, comptime format: []const u8, args: anytype) void {
-        std.fmt.format(self.out, format, args) catch unreachable;
-    }
-
-    fn status(self: Printer, s: Status, comptime format: []const u8, args: anytype) void {
-        const color = switch (s) {
-            .pass => "\x1b[32m",
-            .fail => "\x1b[31m",
-            .skip => "\x1b[33m",
-            else => "",
-        };
-        const out = self.out;
-        out.writeAll(color) catch @panic("writeAll failed?!");
-        std.fmt.format(out, format, args) catch @panic("std.fmt.format failed?!");
-        self.fmt("\x1b[0m", .{});
+    fn status(s: Status, comptime format: []const u8, args: anytype) void {
+        switch (s) {
+            .pass => std.debug.print("\x1b[32m", .{}),
+            .fail => std.debug.print("\x1b[31m", .{}),
+            .skip => std.debug.print("\x1b[33m", .{}),
+            else => {},
+        }
+        std.debug.print(format ++ "\x1b[0m", args);
     }
 };
 
@@ -193,19 +180,22 @@ const Status = enum {
 };
 
 const SlowTracker = struct {
-    const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
     max: usize,
     slowest: SlowestQueue,
-    timer: std.time.Timer,
+    start: Io.Timestamp,
+    allocator: Allocator,
 
-    fn init(allocator: Allocator, count: u32) SlowTracker {
-        const timer = std.time.Timer.start() catch @panic("failed to start timer");
-        var slowest = SlowestQueue.init(allocator, {});
-        slowest.ensureTotalCapacity(count) catch @panic("OOM");
+    const SlowestQueue = std.PriorityDequeue(TestInfo, void, compareTiming);
+
+    fn init(allocator: Allocator, io: Io, count: u32) SlowTracker {
+        const timestamp = Io.Clock.awake.now(io);
+        var slowest: SlowestQueue = .empty;
+        slowest.ensureTotalCapacity(allocator, count) catch @panic("OOM");
         return .{
             .max = count,
-            .timer = timer,
+            .start = timestamp,
             .slowest = slowest,
+            .allocator = allocator,
         };
     }
 
@@ -214,24 +204,26 @@ const SlowTracker = struct {
         name: []const u8,
     };
 
-    fn deinit(self: SlowTracker) void {
-        self.slowest.deinit();
+    fn deinit(self: *SlowTracker) void {
+        self.slowest.deinit(self.allocator);
     }
 
-    fn startTiming(self: *SlowTracker) void {
-        self.timer.reset();
+    fn startTiming(self: *SlowTracker, io: Io) void {
+        self.start = Io.Clock.awake.now(io);
     }
 
-    fn endTiming(self: *SlowTracker, test_name: []const u8) u64 {
-        var timer = self.timer;
-        const ns = timer.lap();
+    fn endTiming(self: *SlowTracker, io: Io, test_name: []const u8) u64 {
+        const timestamp = Io.Clock.awake.now(io);
+        const start = self.start;
+        self.start = timestamp;
+        const ns: u64 = @intCast(start.durationTo(timestamp).toNanoseconds());
 
         var slowest = &self.slowest;
 
         if (slowest.count() < self.max) {
             // Capacity is fixed to the # of slow tests we want to track
             // If we've tracked fewer tests than this capacity, than always add
-            slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+            slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
             return ns;
         }
 
@@ -246,18 +238,18 @@ const SlowTracker = struct {
         }
 
         // the previous fastest of our slow tests, has been pushed off.
-        _ = slowest.removeMin();
-        slowest.add(TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
+        _ = slowest.popMin();
+        slowest.push(self.allocator, TestInfo{ .ns = ns, .name = test_name }) catch @panic("failed to track test timing");
         return ns;
     }
 
-    fn display(self: *SlowTracker, printer: Printer) !void {
+    fn display(self: *SlowTracker) !void {
         var slowest = self.slowest;
         const count = slowest.count();
-        printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
-        while (slowest.removeMinOrNull()) |info| {
+        Printer.fmt("Slowest {d} test{s}: \n", .{ count, if (count != 1) "s" else "" });
+        while (slowest.popMin()) |info| {
             const ms = @as(f64, @floatFromInt(info.ns)) / 1_000_000.0;
-            printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
+            Printer.fmt("  {d:.2}ms\t{s}\n", .{ ms, info.name });
         }
     }
 
@@ -272,34 +264,20 @@ const Env = struct {
     fail_first: bool,
     filter: ?[]const u8,
 
-    fn init(allocator: Allocator) Env {
+    fn init(map: *const std.process.Environ.Map) Env {
         return .{
-            .verbose = readEnvBool(allocator, "TEST_VERBOSE", true),
-            .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
-            .filter = readEnv(allocator, "TEST_FILTER"),
+            .verbose = readEnvBool(map, "TEST_VERBOSE", true),
+            .fail_first = readEnvBool(map, "TEST_FAIL_FIRST", false),
+            .filter = readEnv(map, "TEST_FILTER"),
         };
     }
 
-    fn deinit(self: Env, allocator: Allocator) void {
-        if (self.filter) |f| {
-            allocator.free(f);
-        }
+    fn readEnv(map: *const std.process.Environ.Map, key: []const u8) ?[]const u8 {
+        return map.get(key);
     }
 
-    fn readEnv(allocator: Allocator, key: []const u8) ?[]const u8 {
-        const v = std.process.getEnvVarOwned(allocator, key) catch |err| {
-            if (err == error.EnvironmentVariableNotFound) {
-                return null;
-            }
-            std.log.warn("failed to get env var {s} due to err {}", .{ key, err });
-            return null;
-        };
-        return v;
-    }
-
-    fn readEnvBool(allocator: Allocator, key: []const u8, deflt: bool) bool {
-        const value = readEnv(allocator, key) orelse return deflt;
-        defer allocator.free(value);
+    fn readEnvBool(map: *const std.process.Environ.Map, key: []const u8, deflt: bool) bool {
+        const value = readEnv(map, key) orelse return deflt;
         return std.ascii.eqlIgnoreCase(value, "true");
     }
 };
@@ -327,8 +305,4 @@ fn isSetup(t: std.builtin.TestFn) bool {
 
 fn isTeardown(t: std.builtin.TestFn) bool {
     return std.mem.endsWith(u8, t.name, "tests:afterAll");
-}
-
-fn isAfterEach(t: std.builtin.TestFn) bool {
-    return std.mem.endsWith(u8, t.name, "tests:afterEach");
 }


### PR DESCRIPTION
Hello, I tried to update this library to Zig 0.16. Unfortunately, there are some leaks in test mode, I don't know yet if they are related to changes in code (I tried to minimize tho), in test runner (copied from https://gist.githubusercontent.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/raw/8e82642093d2f4341fb870d18d1fe5b213b2fd11), or something else.

But it works when I just use and import it, so it's already usable (at least for me).

```bash
$ zig-bin-0.16.0 build test
ztl.test_0 (0.01ms)
Value: isTrue (0.03ms)
Value: format (1.00ms)
Value: equal (0.32ms)
writeStringEscaped (0.08ms)
Template: simple (2.14ms)
Template: edge cases (3.39ms)
Template: output literals (1.71ms)
Template: output variable (0.65ms)
Template: space stripping (1.48ms)
Template: escaping (1.37ms)
Template: local and global (0.40ms)
Template: for loop (0.46ms)
Template: error (1.37ms)
Template: runtime error (0.49ms)
Template: map global (0.71ms)
Template: semicolon (1.08ms)
Template: global in function (0.52ms)
Template: string concatenation (2.71ms)
Template: @include (2.62ms)
Template: @include error (0.52ms)
Template: multiple index get (0.80ms)
Template: large (14.56ms)
Template: nested function (0.41ms)
tests:afterEach (0.00ms)
Compiler: local limit (0.46ms)
error(DebugAllocator): memory address 0x74d7a53c0000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x1097aa2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x115f9a5 in allocWithSizeAndAlignment__anon_20539 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x136a24c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1235:56: 0x1369c07 in ensureTotalCapacityPrecise (std.zig)
                const new_memory = try gpa.alignedAlloc(T, alignment, new_capacity);
                                                       ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1211:51: 0x1369919 in ensureTotalCapacity (std.zig)
            return self.ensureTotalCapacityPrecise(gpa, growCapacity(new_capacity));
                                                  ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1265:41: 0x13693dd in addOne (std.zig)
            try self.ensureTotalCapacity(gpa, newlen);
                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:904:49: 0x1368fbd in append (std.zig)
            const new_item_ptr = try self.addOne(gpa);
                                                ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:1446:35: 0x1434d73 in beginScope (ztl.zig)
            try self.scopes.append(self.arena, .{
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:177:32: 0x14351be in compile (ztl.zig)
            try self.beginScope(false);
                               ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3674:18: 0x1861984 in testReturnValueWithApp__anon_101104 (ztl.zig)
        c.compile("<% " ++ src ++ "%>") catch |err| {
                 ^
(additional stack frames may have been skipped...)

error(DebugAllocator): memory address 0x74d7a53a0000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x10a4ff2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x10a4e75 in allocWithSizeAndAlignment__anon_9388 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x10a4b0c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:299:44: 0x138ed7c in toBytes (ztl.zig)
            const buf = try allocator.alloc(u8, 9 + code.pos + script.pos + data.pos);
                                           ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3678:40: 0x186256d in testReturnValueWithApp__anon_101119 (ztl.zig)
        break :blk try c.writer.toBytes(allocator);
                                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3653:31: 0x18638b7 in testReturnValue__anon_101100 (ztl.zig)
    try testReturnValueWithApp(struct {
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:2015:24: 0x1889e05 in test.Compiler: arithmetic (ztl.zig)
    try testReturnValue(.{ .i64 = 9 }, "return 1 + 8;");
                       ^
/tmp/tmp.kstEoQdTP6/ztl/test_runner.zig:97:30: 0x122a828 in main (test_runner.zig)
        const result = t.func();
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:737:30: 0x122c09e in callMain (std.zig)
    return wrapMain(root.main(.{
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:190:5: 0x1229b81 in _start (std.zig)
    asm volatile (switch (native_arch) {
    ^
(additional stack frames may have been skipped...)

error(DebugAllocator): memory address 0x74d7a5380000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x10a4ff2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x10a4e75 in allocWithSizeAndAlignment__anon_9388 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x10a4b0c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:299:44: 0x13ad07c in toBytes (ztl.zig)
            const buf = try allocator.alloc(u8, 9 + code.pos + script.pos + data.pos);
                                           ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3678:40: 0x186522d in testReturnValueWithApp__anon_101165 (ztl.zig)
        break :blk try c.writer.toBytes(allocator);
                                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3660:31: 0x1865b1b in testReturnValue__anon_101139 (ztl.zig)
    try testReturnValueWithApp(struct {
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:2016:24: 0x1889e6f in test.Compiler: arithmetic (ztl.zig)
    try testReturnValue(.{ .i64 = -1 }, "return 10 - 11;");
                       ^
/tmp/tmp.kstEoQdTP6/ztl/test_runner.zig:97:30: 0x122a828 in main (test_runner.zig)
        const result = t.func();
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:737:30: 0x122c09e in callMain (std.zig)
    return wrapMain(root.main(.{
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:190:5: 0x1229b81 in _start (std.zig)
    asm volatile (switch (native_arch) {
    ^
(additional stack frames may have been skipped...)

error(DebugAllocator): memory address 0x74d7a5360000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x1097aa2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x115f9a5 in allocWithSizeAndAlignment__anon_20539 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x136a24c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1235:56: 0x1369c07 in ensureTotalCapacityPrecise (std.zig)
                const new_memory = try gpa.alignedAlloc(T, alignment, new_capacity);
                                                       ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1211:51: 0x1369919 in ensureTotalCapacity (std.zig)
            return self.ensureTotalCapacityPrecise(gpa, growCapacity(new_capacity));
                                                  ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1265:41: 0x13693dd in addOne (std.zig)
            try self.ensureTotalCapacity(gpa, newlen);
                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:904:49: 0x1368fbd in append (std.zig)
            const new_item_ptr = try self.addOne(gpa);
                                                ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:1446:35: 0x13dff43 in beginScope (ztl.zig)
            try self.scopes.append(self.arena, .{
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:177:32: 0x13e038e in compile (ztl.zig)
            try self.beginScope(false);
                               ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3674:18: 0x186b704 in testReturnValueWithApp__anon_101279 (ztl.zig)
        c.compile("<% " ++ src ++ "%>") catch |err| {
                 ^
(additional stack frames may have been skipped...)

error(DebugAllocator): memory address 0x74d7a5340000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x1097aa2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x115f9a5 in allocWithSizeAndAlignment__anon_20539 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x136a24c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1235:56: 0x1369c07 in ensureTotalCapacityPrecise (std.zig)
                const new_memory = try gpa.alignedAlloc(T, alignment, new_capacity);
                                                       ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1211:51: 0x1369919 in ensureTotalCapacity (std.zig)
            return self.ensureTotalCapacityPrecise(gpa, growCapacity(new_capacity));
                                                  ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:1265:41: 0x13693dd in addOne (std.zig)
            try self.ensureTotalCapacity(gpa, newlen);
                                        ^
/opt/zig-bin-0.16.0/lib/std/array_list.zig:904:49: 0x1368fbd in append (std.zig)
            const new_item_ptr = try self.addOne(gpa);
                                                ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:1446:35: 0x140a903 in beginScope (ztl.zig)
            try self.scopes.append(self.arena, .{
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:177:32: 0x140ad4e in compile (ztl.zig)
            try self.beginScope(false);
                               ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3674:18: 0x1877844 in testReturnValueWithApp__anon_101508 (ztl.zig)
        c.compile("<% " ++ src ++ "%>") catch |err| {
                 ^
(additional stack frames may have been skipped...)

error(DebugAllocator): memory address 0x74d7a5320000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x10a4ff2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x10a4e75 in allocWithSizeAndAlignment__anon_9388 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x10a4b0c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:331:46: 0x13011a9 in write (ztl.zig)
                    buf = try allocator.alloc(u8, initial_size);
                                             ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:60:36: 0x140ab75 in op (ztl.zig)
            return self.frame.write(self.allocator, &.{@intFromEnum(op_code)});
                                   ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:68:24: 0x1411b44 in opWithData (ztl.zig)
            try self.op(op_code);
                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:216:35: 0x142a365 in f64 (ztl.zig)
            return self.opWithData(.CONSTANT_F64, std.mem.asBytes(&value));
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:993:54: 0x142a4de in number (ztl.zig)
                .FLOAT => |value| try self.writer.f64(value),
                                                     ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:935:31: 0x1421fa6 in parsePrecedence (ztl.zig)
                    try prefix(self, can_assign);
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:907:40: 0x1421a56 in expression (ztl.zig)
            return self.parsePrecedence(.ASSIGNMENT);
                                       ^
(additional stack frames may have been skipped...)


================================================================================
"Compiler: arithmetic" - Memory Leak
================================================================================
Compiler: arithmetic (1.19ms)
Compiler: not (0.37ms)
error(DebugAllocator): memory address 0x74d7a366a000 leaked:
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x10a4ff2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x10a4e75 in allocWithSizeAndAlignment__anon_9388 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x10a4b0c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:331:46: 0x13011a9 in write (ztl.zig)
                    buf = try allocator.alloc(u8, initial_size);
                                             ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:60:36: 0x13e01b5 in op (ztl.zig)
            return self.frame.write(self.allocator, &.{@intFromEnum(op_code)});
                                   ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:68:24: 0x13e7184 in opWithData (ztl.zig)
            try self.op(op_code);
                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:212:35: 0x13f8d33 in i64 (ztl.zig)
            return self.opWithData(.CONSTANT_I64, std.mem.asBytes(&value));
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:992:56: 0x13fffd8 in number (ztl.zig)
                .INTEGER => |value| try self.writer.i64(value),
                                                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:935:31: 0x13f7b06 in parsePrecedence (ztl.zig)
                    try prefix(self, can_assign);
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:907:40: 0x13f75b6 in expression (ztl.zig)
            return self.parsePrecedence(.ASSIGNMENT);
                                       ^
(additional stack frames may have been skipped...)


================================================================================
"Compiler: comparison int" - Memory Leak
================================================================================
Compiler: comparison int (0.55ms)
================================================================================
panic running "Compiler: comparison float"
================================================================================
thread 301 panic: Invalid free
/tmp/tmp.kstEoQdTP6/ztl/test_runner.zig:290:31: 0x107b9a9 in panicFn (test_runner.zig)
        std.debug.defaultPanic(msg, first_trace_addr);
                              ^
/opt/zig-bin-0.16.0/lib/std/heap/debug_allocator.zig:553:21: 0x136d70c in resizeLarge (std.zig)
                    @panic("Invalid free");
                    ^
/opt/zig-bin-0.16.0/lib/std/heap/debug_allocator.zig:839:40: 0x136eea2 in resize (std.zig)
                return self.resizeLarge(memory, alignment, new_len, return_address, false) != null;
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:148:27: 0x10992e3 in rawResize (std.zig)
    return a.vtable.resize(a.ptr, memory, alignment, new_len, ret_addr);
                          ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:142:26: 0x10a4ff2 in rawAlloc (std.zig)
    return a.vtable.alloc(a.ptr, len, alignment, ret_addr);
                         ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:286:40: 0x10a4e75 in allocWithSizeAndAlignment__anon_9388 (std.zig)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/opt/zig-bin-0.16.0/lib/std/mem/Allocator.zig:274:89: 0x10a4b0c in allocAdvancedWithRetAddr (std.zig)
    const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                                        ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:331:46: 0x13011a9 in write (ztl.zig)
                    buf = try allocator.alloc(u8, initial_size);
                                             ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:60:36: 0x1434fe5 in op (ztl.zig)
            return self.frame.write(self.allocator, &.{@intFromEnum(op_code)});
                                   ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:68:24: 0x1439774 in opWithData (ztl.zig)
            try self.op(op_code);
                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/byte_code.zig:216:35: 0x1455b95 in f64 (ztl.zig)
            return self.opWithData(.CONSTANT_F64, std.mem.asBytes(&value));
                                  ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:993:54: 0x1455d0e in number (ztl.zig)
                .FLOAT => |value| try self.writer.f64(value),
                                                     ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:935:31: 0x144d216 in parsePrecedence (ztl.zig)
                    try prefix(self, can_assign);
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:907:40: 0x144ccc6 in expression (ztl.zig)
            return self.parsePrecedence(.ASSIGNMENT);
                                       ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:732:44: 0x144449e in statement (ztl.zig)
                        try self.expression();
                                           ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:375:50: 0x143bd02 in declaration (ztl.zig)
                    else => return self.statement(),
                                                 ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:180:37: 0x143571c in compile (ztl.zig)
                try self.declaration();
                                    ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3674:18: 0x1820a74 in testReturnValueWithApp__anon_99961 (ztl.zig)
        c.compile("<% " ++ src ++ "%>") catch |err| {
                 ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:3646:31: 0x1822943 in testReturnValue__anon_99957 (ztl.zig)
    try testReturnValueWithApp(struct {
                              ^
/tmp/tmp.kstEoQdTP6/ztl/src/compiler.zig:2072:24: 0x183a29d in test.Compiler: comparison float (ztl.zig)
    try testReturnValue(.{ .bool = false }, "return 1.13 > 1.13;");
                       ^
/tmp/tmp.kstEoQdTP6/ztl/test_runner.zig:97:30: 0x122a828 in main (test_runner.zig)
        const result = t.func();
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:737:30: 0x122c09e in callMain (std.zig)
    return wrapMain(root.main(.{
                             ^
/opt/zig-bin-0.16.0/lib/std/start.zig:190:5: 0x1229b81 in _start (std.zig)
    asm volatile (switch (native_arch) {
    ^
test
└─ run test failure
error: process terminated with signal ABRT
failed command: ./.zig-cache/o/926a6b06c608ea40895f98418b6815c4/test

Build Summary: 1/3 steps succeeded (1 failed)
test transitive failure
└─ run test failure

error: the following build command failed with exit code 1:
.zig-cache/o/4ce4b4aba0d87bdf13b305a078630cfb/build /opt/zig-bin-0.16.0/zig /opt/zig-bin-0.16.0/lib /tmp/tmp.kstEoQdTP6/ztl .zig-cache /home/bratishkaerik/.cache/zig --seed 0xe844b652 -Z2b45f9fc27a1cad9 test
```